### PR TITLE
feat: 챗봇과 공지요약 API

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.schemas.chat import ChatRequest, ChatResponse
+from app.services.validator import validate_question
+from app.services.embeddings import create_query_embedding
+from app.services.generator import generate_answer
+from app.repositories.regulation_chunk_repository import search_similar_chunks
+from app.db.session import get_db
+
+router = APIRouter(prefix="/ai/chat", tags=["chat"])
+
+
+@router.post("", response_model=ChatResponse)
+def chat(request: ChatRequest, db: Session = Depends(get_db)):
+    print("1. request:", request)
+
+    is_valid, normalized_question = validate_question(request.question)
+    print("2. validator:", is_valid, normalized_question)
+
+    if not is_valid:
+        return ChatResponse(
+            answer="기숙사 관련 질문을 입력해주세요.",
+            source_url=""
+        )
+
+    query_embedding = create_query_embedding(normalized_question)
+    print("3. embedding 생성 완료")
+
+    chunks = search_similar_chunks(
+        db=db,
+        query_embedding=query_embedding,
+        dormitory=request.dormitory,
+        top_k=3
+    )
+    print("4. 검색 결과:", chunks)
+
+    answer, source_url = generate_answer(normalized_question, chunks)
+    print("5. 답변 생성 완료")
+
+    return ChatResponse(
+        answer=answer,
+        source_url=source_url or ""
+    )

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -13,10 +13,8 @@ router = APIRouter(prefix="/ai/chat", tags=["chat"])
 
 @router.post("", response_model=ChatResponse)
 def chat(request: ChatRequest, db: Session = Depends(get_db)):
-    print("1. request:", request)
 
     is_valid, normalized_question = validate_question(request.question)
-    print("2. validator:", is_valid, normalized_question)
 
     if not is_valid:
         return ChatResponse(
@@ -25,7 +23,6 @@ def chat(request: ChatRequest, db: Session = Depends(get_db)):
         )
 
     query_embedding = create_query_embedding(normalized_question)
-    print("3. embedding 생성 완료")
 
     chunks = search_similar_chunks(
         db=db,
@@ -33,10 +30,8 @@ def chat(request: ChatRequest, db: Session = Depends(get_db)):
         dormitory=request.dormitory,
         top_k=3
     )
-    print("4. 검색 결과:", chunks)
 
     answer, source_url = generate_answer(normalized_question, chunks)
-    print("5. 답변 생성 완료")
 
     return ChatResponse(
         answer=answer,

--- a/app/api/notice.py
+++ b/app/api/notice.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+from app.schemas.notice import NoticeRequest, NoticeResponse
+from app.services.summarizer import summarize_notice
+
+router = APIRouter(prefix="/ai/notice_summary", tags=["notice"])
+
+
+@router.post("", response_model=NoticeResponse)
+def summarize_notice_api(request: NoticeRequest):
+    summary = summarize_notice(request.title, request.content)
+    return NoticeResponse(summary=summary)

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -4,3 +4,11 @@ from app.api.admin_regulation_chunks import router as admin_regulation_chunks_ro
 
 api_router = APIRouter()
 api_router.include_router(admin_regulation_chunks_router)
+
+# feat#6에서 추가
+
+from app.api.chat import router as chat_router
+from app.api.notice import router as notice_router
+
+api_router.include_router(chat_router)
+api_router.include_router(notice_router)

--- a/app/repositories/regulation_chunk_repository.py
+++ b/app/repositories/regulation_chunk_repository.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+
 from app.db.models.regulation_chunk import RegulationChunk
 from app.schemas.regulation_chunk import RegulationChunkCreateRequest
 
@@ -53,3 +54,51 @@ def create_regulation_chunk(
     db.flush()
     db.refresh(regulation_chunk)
     return regulation_chunk
+
+
+# feat#6에서 추가(조회용 함수 추가)
+from sqlalchemy import text
+
+
+def search_similar_chunks(
+    db: Session,
+    query_embedding: list[float],
+    dormitory: str,
+    top_k: int = 3,
+):
+    """질문 임베딩과 유사한 regulation_chunk를 pgvector로 검색합니다."""
+
+    embedding_str = "[" + ",".join(map(str, query_embedding)) + "]"
+
+    sql = text(
+        """
+        SELECT
+            chunk_id,
+            content,
+            source_url,
+            1 - (embedding <=> CAST(:embedding AS vector)) AS similarity
+        FROM regulation_chunk
+        WHERE dormitory = :dormitory OR dormitory IS NULL
+        ORDER BY embedding <=> CAST(:embedding AS vector)
+        LIMIT :top_k
+        """
+    )
+
+    result = db.execute(
+        sql,
+        {
+            "embedding": embedding_str,
+            "dormitory": dormitory,
+            "top_k": top_k,
+        },
+    ).mappings().all()
+
+    return [
+        {
+            "chunk_id": row.chunk_id,
+            "content": row.content,
+            "source_url": row.source_url,
+            "similarity": float(row.similarity),
+        }
+        for row in result
+    ]

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class ChatRequest(BaseModel):
+    question: str
+    dormitory: str
+
+
+class ChatResponse(BaseModel):
+    answer: str
+    source_url: str

--- a/app/schemas/notice.py
+++ b/app/schemas/notice.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class NoticeRequest(BaseModel):
+    title: str
+    content: str
+
+
+class NoticeResponse(BaseModel):
+    summary: str

--- a/app/services/embeddings.py
+++ b/app/services/embeddings.py
@@ -1,0 +1,15 @@
+import os
+
+from app.core.config import get_settings
+from openai import OpenAI
+
+settings = get_settings()
+client = OpenAI(api_key=settings.openai_api_key)
+
+
+def create_query_embedding(text: str) -> list[float]:
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=text
+    )
+    return response.data[0].embedding

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -1,4 +1,3 @@
-import os
 
 from app.core.config import get_settings
 from openai import OpenAI
@@ -30,7 +29,7 @@ def generate_answer(question: str, chunks: list[dict]) -> tuple[str, str]:
 """
 
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-4o-mini",
         temperature=0.3,
         messages=[
             {"role": "user", "content": prompt}

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -1,0 +1,45 @@
+import os
+
+from app.core.config import get_settings
+from openai import OpenAI
+
+settings = get_settings()
+client = OpenAI(api_key=settings.openai_api_key)
+
+
+def generate_answer(question: str, chunks: list[dict]) -> tuple[str, str]:
+    """
+    검색된 chunk들을 기반으로 최종 답변 생성
+    """
+
+    if not chunks:
+        return "관련 정보를 찾을 수 없습니다.", ""
+
+    context = "\n\n".join([chunk["content"] for chunk in chunks])
+
+    prompt = f"""
+너는 기숙사 안내 챗봇이다.
+아래 제공된 정보를 기반으로만 질문에 답변해라.
+모르는 내용은 추측하지 말고 모른다고 말해라.
+
+[질문]
+{question}
+
+[참고 정보]
+{context}
+"""
+
+    response = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        temperature=0.3,
+        messages=[
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    answer = response.choices[0].message.content.strip()
+
+    # 첫 번째 chunk의 source_url 사용
+    source_url = chunks[0].get("source_url", "")
+
+    return answer, source_url

--- a/app/services/summarizer.py
+++ b/app/services/summarizer.py
@@ -20,7 +20,7 @@ def summarize_notice(title: str, content: str) -> str:
 """
 
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-4o-mini",
         temperature=0.3,
         messages=[
             {"role": "user", "content": prompt}

--- a/app/services/summarizer.py
+++ b/app/services/summarizer.py
@@ -1,0 +1,30 @@
+import os
+
+from app.core.config import get_settings
+from openai import OpenAI
+
+settings = get_settings()
+client = OpenAI(api_key=settings.openai_api_key)
+
+
+def summarize_notice(title: str, content: str) -> str:
+    prompt = f"""
+다음 공지사항을 2~4문장으로 간단명료하게 요약해줘.
+중요한 일정, 장소, 대상, 유의사항이 있으면 포함해줘.
+
+제목:
+{title}
+
+본문:
+{content}
+"""
+
+    response = client.chat.completions.create(
+        model="gpt-4.1-mini",
+        temperature=0.3,
+        messages=[
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    return response.choices[0].message.content.strip()

--- a/app/services/validator.py
+++ b/app/services/validator.py
@@ -1,0 +1,14 @@
+def validate_question(question: str) -> tuple[bool, str]:
+    """
+    질문이 기숙사 관련인지 간단하게 검증하고
+    정규화된 질문을 반환
+    """
+
+    if not question or len(question.strip()) < 2:
+        return False, "질문이 너무 짧습니다."
+
+    # 기본 정규화
+    normalized = question.strip()
+
+    # (지금은 단순 검증, 나중에 LLM 붙일 수 있음)
+    return True, normalized


### PR DESCRIPTION
## 유형

- [x] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

- FastAPI 기반 AI 서버 구조에 맞춰 챗봇 API와 공지사항 요약 API를 구현했습니다.(공지사항 API는 우선 내용 받아서 요약하는 형식으로만 동작합니다, 저번에 진도표 짤 때 공지사항 요약에 대해서 더 이야기 하셨던거 같은데 나중에 회의 때 확인하고 추가하거나 수정하겠습니다.)
- 챗봇 API는 질문 검증 → 질문 임베딩 생성 → pgvector 기반 regulation_chunk 검색 → LLM 답변 생성 흐름으로 구성했습니다.
- 공지사항 요약 API는 제목/본문을 입력받아 LLM으로 요약하도록 구현했습니다.
- 기존 프로젝트 구조에 맞춰 API, schema, service, repository 레이어에 기능을 분리했습니다.
- regulation_chunk repository에 유사 청크 검색 함수를 추가했습니다.
- Swagger에서 관리자 regulation chunk 적재 API를 통해 JSON 데이터를 로컬 DB에 적재한 후 챗봇 응답까지 동작하는 것을 확인했습니다.

## 변경 사항

-API
- `POST /api/v1/ai/chat`
- `POST /api/v1/ai/notice_summary`

-Schema
- 챗봇 요청/응답 스키마 추가
- 공지사항 요약 요청/응답 스키마 추가

-Service
- 질문 검증 로직 추가
- 질문 임베딩 생성 로직 추가
- 검색 결과 기반 답변 생성 로직 추가
- 공지사항 요약 로직 추가

-Repository
- `regulation_chunk` 대상 pgvector 유사 검색 로직 추가

## 변경 파일 및 역할

-API
- `app/api/chat.py`
  - 챗봇 API 엔드포인트 추가
  - 질문 검증 → 임베딩 생성 → pgvector 검색 → 답변 생성 흐름 연결

- `app/api/notice.py`
  - 공지사항 요약 API 엔드포인트 추가
  - 제목/본문 입력을 받아 요약 결과 반환

- `app/api/router.py`
  - 새로 추가한 chat/notice 라우터를 전체 API 라우터에 등록

-Schema
- `app/schemas/chat.py`
  - 챗봇 요청/응답 형식 정의
  - 요청: `question`, `dormitory`
  - 응답: `answer`, `source_url`

- `app/schemas/notice.py`
  - 공지사항 요약 요청/응답 형식 정의
  - 요청: `title`, `content`
  - 응답: `summary`

-Service
- `app/services/validator.py`
  - 사용자 질문의 유효성 검사 및 정규화 처리

- `app/services/embeddings.py`
  - 사용자 질문을 OpenAI 임베딩 벡터로 변환

- `app/services/generator.py`
  - 검색된 regulation chunk를 기반으로 최종 자연어 답변 생성

- `app/services/summarizer.py`
  - 공지사항 제목/본문을 요약하는 로직 구현


## 테스트

- 서버 실행 및 `/docs`에서 API 노출 확인
- 공지사항 요약 API 정상 응답 확인
- 관리자 regulation chunk bulk 적재 API로 JSON 데이터 적재 확인
- 적재 후 챗봇 API에서 질의응답 동작 확인

## 스크린샷
<img width="1775" height="661" alt="챗봇 테스트 이미지1" src="https://github.com/user-attachments/assets/d859759a-baca-4630-8089-5b4fd7e64f78" />

<img width="1767" height="663" alt="챗봇 테스트 이미지2" src="https://github.com/user-attachments/assets/0135f985-bb6c-4870-a1f6-8f4b7c786551" />

<img width="1767" height="657" alt="공지 요약 테스트 이미지1" src="https://github.com/user-attachments/assets/09b43ad5-76b4-4baa-a8a6-847c265369a0" />



