### PR TITLE
fix: 챗봇 API dormitory null 처리 및 응답 개선

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from app.schemas.chat import ChatRequest, ChatResponse
 from app.services.validator import validate_question
 from app.services.embeddings import create_query_embedding
-from app.services.generator import generate_answer
+from app.services.generator import generate_answer, generate_grouped_answer
 from app.repositories.regulation_chunk_repository import search_similar_chunks
 from app.db.session import get_db
 
@@ -13,7 +13,6 @@ router = APIRouter(prefix="/ai/chat", tags=["chat"])
 
 @router.post("", response_model=ChatResponse)
 def chat(request: ChatRequest, db: Session = Depends(get_db)):
-
     is_valid, normalized_question = validate_question(request.question)
 
     if not is_valid:
@@ -24,14 +23,36 @@ def chat(request: ChatRequest, db: Session = Depends(get_db)):
 
     query_embedding = create_query_embedding(normalized_question)
 
-    chunks = search_similar_chunks(
-        db=db,
-        query_embedding=query_embedding,
-        dormitory=request.dormitory,
-        top_k=3
-    )
+    # dormitory가 있는 경우: 기존 방식 유지
+    if request.dormitory:
+        chunks = search_similar_chunks(
+            db=db,
+            query_embedding=query_embedding,
+            dormitory=request.dormitory,
+            top_k=3
+        )
 
-    answer, source_url = generate_answer(normalized_question, chunks)
+        answer, source_url = generate_answer(normalized_question, chunks)
+
+        return ChatResponse(
+            answer=answer,
+            source_url=source_url or ""
+        )
+
+    # dormitory가 없는 경우: 생활관별로 각각 검색
+    dormitories = ["제1학생생활관", "제2학생생활관", "제3학생생활관"]
+    dormitory_chunks: dict[str, list[dict]] = {}
+
+    for dormitory in dormitories:
+        chunks = search_similar_chunks(
+            db=db,
+            query_embedding=query_embedding,
+            dormitory=dormitory,
+            top_k=2
+        )
+        dormitory_chunks[dormitory] = chunks
+
+    answer, source_url = generate_grouped_answer(normalized_question, dormitory_chunks)
 
     return ChatResponse(
         answer=answer,

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,9 +1,9 @@
 from pydantic import BaseModel
-
+from typing import Optional
 
 class ChatRequest(BaseModel):
     question: str
-    dormitory: str
+    dormitory: Optional[str] = None
 
 
 class ChatResponse(BaseModel):

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -42,3 +42,55 @@ def generate_answer(question: str, chunks: list[dict]) -> tuple[str, str]:
     source_url = chunks[0].get("source_url", "")
 
     return answer, source_url
+
+
+def generate_grouped_answer(question: str, dormitory_chunks: dict[str, list[dict]]) -> tuple[str, str]:
+    """
+    dormitory가 없을 때 생활관별 검색 결과를 나눠서 답변 생성
+    """
+    available = {k: v for k, v in dormitory_chunks.items() if v}
+
+    if not available:
+        return "관련 정보를 찾을 수 없습니다.", ""
+
+    context_parts = []
+    first_source_url = ""
+
+    for dormitory, chunks in available.items():
+        if not first_source_url and chunks:
+            first_source_url = chunks[0].get("source_url", "")
+
+        joined = "\n".join([f"- {chunk['content']}" for chunk in chunks])
+        context_parts.append(f"[{dormitory}]\n{joined}")
+
+    context = "\n\n".join(context_parts)
+
+    prompt = f"""
+너는 기숙사 안내 챗봇이다.
+아래 제공된 정보를 기반으로만 답변해라.
+반드시 생활관별로 구분해서 설명해라.
+정보가 없는 생활관은 언급하지 않아도 된다.
+모르는 내용은 추측하지 말고 제공된 정보 범위에서만 답변해라.
+
+출력 형식 예시:
+제1학생생활관: ...
+제2학생생활관: ...
+제3학생생활관: ...
+
+[질문]
+{question}
+
+[생활관별 참고 정보]
+{context}
+"""
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        temperature=0.3,
+        messages=[
+            {"role": "user", "content": prompt}
+        ]
+    )
+
+    answer = response.choices[0].message.content.strip()
+    return answer, first_source_url


### PR DESCRIPTION
## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용
- 챗봇 API에서 dormitory를 optional로 처리
- dormitory가 null일 경우 제1/제2/제3학생생활관을 각각 조회
- 생활관별로 구분된 답변 생성하도록 개선


## 변경 파일
- app/api/chat.py
- app/services/generator.py
- app/schemas/chat.py

## 테스트
- dormitory 지정 요청 정상 동작 확인
- dormitory null 요청 시 생활관별 응답 생성 확인

Closes #10

