### PR TITLE
[Feat] 챗봇 세션, 응답 추적 및 오류 로그 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-APP_ENV=dev
-APP_NAME=gaon-i-ai
-API_V1_PREFIX=/api/v1
-DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/gaon_i
-OPENAI_API_KEY=

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -17,7 +17,8 @@ Gaon-i AI 서버의 초기 개발 환경과 개발 원칙을 정리한 문서입
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install ".[dev]"
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
 cp .env.example .env.dev
 uvicorn app.main:app --reload
 ```

--- a/app/api/admin_chat.py
+++ b/app/api/admin_chat.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Path
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.admin_auth import require_admin_token
+from app.db.session import get_db
+from app.schemas.admin_chat import AdminChatLogDetail
+from app.schemas.admin_chat import AdminRecentChatSessionsResult
+from app.schemas.common import ApiResponse
+from app.services.admin_chat_service import get_admin_chat_log_detail
+from app.services.admin_chat_service import get_recent_admin_chat_sessions
+
+router = APIRouter(
+    prefix="/admin/chat",
+    tags=["admin-chat"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+
+@router.get(
+    "/logs/{chat_log_id}",
+    response_model=ApiResponse[AdminChatLogDetail],
+    status_code=status.HTTP_200_OK,
+    summary="채팅 로그 단건 조회",
+    description="관리자가 `chat_log_id` 기준으로 질문/답변 상태와 메타데이터를 조회합니다.",
+)
+def get_admin_chat_log_api(
+    chat_log_id: int = Path(ge=1),
+    db: Session = Depends(get_db),
+) -> ApiResponse[AdminChatLogDetail]:
+    result = get_admin_chat_log_detail(db, chat_log_id)
+    return ApiResponse(
+        status=status.HTTP_200_OK,
+        message="chat log retrieved",
+        data=result,
+    )
+
+
+@router.get(
+    "/sessions/recent",
+    response_model=ApiResponse[AdminRecentChatSessionsResult],
+    status_code=status.HTTP_200_OK,
+    summary="최신 채팅 세션 10건 조회",
+    description="관리자가 `chat_session` 테이블에서 최근 활동 기준 최신 10개 세션을 조회합니다.",
+)
+def get_recent_admin_chat_sessions_api(
+    db: Session = Depends(get_db),
+) -> ApiResponse[AdminRecentChatSessionsResult]:
+    result = get_recent_admin_chat_sessions(db)
+    return ApiResponse(
+        status=status.HTTP_200_OK,
+        message="recent chat sessions retrieved",
+        data=result,
+    )

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -3,10 +3,7 @@ from sqlalchemy.orm import Session
 
 from app.schemas.chat import ChatRequest, ChatResponse
 from app.schemas.chat import ChatSessionCreateRequest, ChatSessionCreateResponse
-from app.services.validator import validate_question
-from app.services.embeddings import create_query_embedding
-from app.services.generator import generate_answer, generate_grouped_answer
-from app.repositories.regulation_chunk_repository import search_similar_chunks
+from app.services.chat_service import answer_chat_question
 from app.services.chat_session_service import start_chat_session
 from app.db.session import get_db
 
@@ -31,48 +28,4 @@ def start_chat_session_api(
 
 @router.post("", response_model=ChatResponse)
 def chat(request: ChatRequest, db: Session = Depends(get_db)):
-    is_valid, normalized_question = validate_question(request.question)
-
-    if not is_valid:
-        return ChatResponse(
-            answer="기숙사 관련 질문을 입력해주세요.",
-            source_url=""
-        )
-
-    query_embedding = create_query_embedding(normalized_question)
-
-    # dormitory가 있는 경우: 기존 방식 유지
-    if request.dormitory:
-        chunks = search_similar_chunks(
-            db=db,
-            query_embedding=query_embedding,
-            dormitory=request.dormitory,
-            top_k=3
-        )
-
-        answer, source_url = generate_answer(normalized_question, chunks)
-
-        return ChatResponse(
-            answer=answer,
-            source_url=source_url or ""
-        )
-
-    # dormitory가 없는 경우: 생활관별로 각각 검색
-    dormitories = ["제1학생생활관", "제2학생생활관", "제3학생생활관"]
-    dormitory_chunks: dict[str, list[dict]] = {}
-
-    for dormitory in dormitories:
-        chunks = search_similar_chunks(
-            db=db,
-            query_embedding=query_embedding,
-            dormitory=dormitory,
-            top_k=2
-        )
-        dormitory_chunks[dormitory] = chunks
-
-    answer, source_url = generate_grouped_answer(normalized_question, dormitory_chunks)
-
-    return ChatResponse(
-        answer=answer,
-        source_url=source_url or ""
-    )
+    return answer_chat_question(db, request)

--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -2,13 +2,31 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.schemas.chat import ChatRequest, ChatResponse
+from app.schemas.chat import ChatSessionCreateRequest, ChatSessionCreateResponse
 from app.services.validator import validate_question
 from app.services.embeddings import create_query_embedding
 from app.services.generator import generate_answer, generate_grouped_answer
 from app.repositories.regulation_chunk_repository import search_similar_chunks
+from app.services.chat_session_service import start_chat_session
 from app.db.session import get_db
 
 router = APIRouter(prefix="/ai/chat", tags=["chat"])
+
+
+@router.post(
+    "/sessions",
+    response_model=ChatSessionCreateResponse,
+    summary="채팅 세션 시작",
+    description=(
+        "새로운 채팅 세션을 생성하고 `session_id`를 반환합니다.\n\n"
+        "이후 질문 요청에서 이 세션 ID를 사용해 대화 로그와 사용자 활동을 연결할 수 있습니다."
+    ),
+)
+def start_chat_session_api(
+    request: ChatSessionCreateRequest,
+    db: Session = Depends(get_db),
+):
+    return start_chat_session(db, request)
 
 
 @router.post("", response_model=ChatResponse)

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter
 
+from app.api.admin_chat import router as admin_chat_router
 from app.api.admin_regulation_documents import router as admin_regulation_documents_router
 from app.api.admin_regulation_chunk_ingestion import router as admin_regulation_chunk_ingestion_router
 
 api_router = APIRouter()
+api_router.include_router(admin_chat_router)
 api_router.include_router(admin_regulation_documents_router)
 api_router.include_router(admin_regulation_chunk_ingestion_router)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     openai_embedding_model: str = "text-embedding-3-small"
     openai_embedding_dimension: int = 1536
     openai_timeout_seconds: float = 10.0
+    chat_session_timeout_minutes: int = 30
 
 
 @lru_cache

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     openai_embedding_model: str = "text-embedding-3-small"
     openai_embedding_dimension: int = 1536
     openai_timeout_seconds: float = 10.0
+    regulation_chunk_max_length: int = 800
     chat_session_timeout_minutes: int = 30
 
 

--- a/app/core/error_codes.py
+++ b/app/core/error_codes.py
@@ -182,3 +182,18 @@ NOTICE_DELETE_FAILED = ErrorCode(
     message="failed to delete expired notices",
     status=500,
 )
+CHAT_SESSION_NOT_FOUND = ErrorCode(
+    code="CHAT_SESSION_NOT_FOUND",
+    message="chat session not found",
+    status=404,
+)
+CHAT_SESSION_EXPIRED = ErrorCode(
+    code="CHAT_SESSION_EXPIRED",
+    message="chat session expired",
+    status=409,
+)
+CHAT_LOG_NOT_FOUND = ErrorCode(
+    code="CHAT_LOG_NOT_FOUND",
+    message="chat log not found",
+    status=404,
+)

--- a/app/core/time_utils.py
+++ b/app/core/time_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone
 from zoneinfo import ZoneInfo
 
 
@@ -6,3 +7,9 @@ def get_current_kst_time() -> datetime:
     """운영 기준 시각을 KST 기준 naive datetime으로 맞춥니다."""
 
     return datetime.now(ZoneInfo("Asia/Seoul")).replace(tzinfo=None)
+
+
+def get_current_utc_time() -> datetime:
+    """서버 저장 기준 시각을 UTC 기준 naive datetime으로 맞춥니다."""
+
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/app/repositories/admin_chat_repository.py
+++ b/app/repositories/admin_chat_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy import desc
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.db.models.chat_error_log import ChatErrorLog
 from app.db.models.chat_log import ChatLog
 from app.db.models.chat_retrieval_result import ChatRetrievalResult
 from app.db.models.chat_session import ChatSession
@@ -34,5 +35,17 @@ def list_chat_retrieval_results_by_chat_log_id(
             ChatRetrievalResult.retrieval_rank.asc(),
             ChatRetrievalResult.chat_retrieval_result_id.asc(),
         )
+    )
+    return list(db.execute(statement).scalars().all())
+
+
+def list_chat_error_logs_by_chat_log_id(
+    db: Session,
+    chat_log_id: int,
+) -> list[ChatErrorLog]:
+    statement = (
+        select(ChatErrorLog)
+        .where(ChatErrorLog.chat_log_id == chat_log_id)
+        .order_by(ChatErrorLog.created_at.asc(), ChatErrorLog.error_id.asc())
     )
     return list(db.execute(statement).scalars().all())

--- a/app/repositories/admin_chat_repository.py
+++ b/app/repositories/admin_chat_repository.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from sqlalchemy import desc
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.chat_log import ChatLog
+from app.db.models.chat_retrieval_result import ChatRetrievalResult
+from app.db.models.chat_session import ChatSession
+
+
+def get_chat_log_by_id(db: Session, chat_log_id: int) -> Optional[ChatLog]:
+    statement = select(ChatLog).where(ChatLog.chat_log_id == chat_log_id)
+    return db.execute(statement).scalar_one_or_none()
+
+
+def list_recent_chat_sessions(db: Session, limit: int = 10) -> list[ChatSession]:
+    statement = (
+        select(ChatSession)
+        .order_by(desc(ChatSession.last_activity_at), desc(ChatSession.started_at))
+        .limit(limit)
+    )
+    return list(db.execute(statement).scalars().all())
+
+
+def list_chat_retrieval_results_by_chat_log_id(
+    db: Session,
+    chat_log_id: int,
+) -> list[ChatRetrievalResult]:
+    statement = (
+        select(ChatRetrievalResult)
+        .where(ChatRetrievalResult.chat_log_id == chat_log_id)
+        .order_by(
+            ChatRetrievalResult.retrieval_rank.asc(),
+            ChatRetrievalResult.chat_retrieval_result_id.asc(),
+        )
+    )
+    return list(db.execute(statement).scalars().all())

--- a/app/repositories/chat_error_log_repository.py
+++ b/app/repositories/chat_error_log_repository.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.time_utils import get_current_utc_time
+from app.db.models.chat_error_log import ChatErrorLog
+
+
+def create_chat_error_log(
+    db: Session,
+    *,
+    chat_log_id: int,
+    session_id: Optional[str],
+    error_type: str,
+    error_message: str,
+    error_detail: Optional[str],
+    occurred_step: Optional[str],
+) -> ChatErrorLog:
+    chat_error_log = ChatErrorLog(
+        chat_log_id=chat_log_id,
+        session_id=session_id,
+        error_type=error_type,
+        error_message=error_message,
+        error_detail=error_detail,
+        occurred_step=occurred_step,
+        created_at=get_current_utc_time(),
+    )
+    db.add(chat_error_log)
+    db.flush()
+    db.refresh(chat_error_log)
+    return chat_error_log
+
+
+def list_chat_error_logs_by_chat_log_id(
+    db: Session,
+    chat_log_id: int,
+) -> list[ChatErrorLog]:
+    statement = (
+        select(ChatErrorLog)
+        .where(ChatErrorLog.chat_log_id == chat_log_id)
+        .order_by(ChatErrorLog.created_at.asc(), ChatErrorLog.error_id.asc())
+    )
+    return list(db.execute(statement).scalars().all())

--- a/app/repositories/chat_log_repository.py
+++ b/app/repositories/chat_log_repository.py
@@ -14,6 +14,11 @@ def get_chat_session(db: Session, session_id: str) -> Optional[ChatSession]:
     return db.execute(statement).scalar_one_or_none()
 
 
+def get_chat_log_by_id(db: Session, chat_log_id: int) -> Optional[ChatLog]:
+    statement = select(ChatLog).where(ChatLog.chat_log_id == chat_log_id)
+    return db.execute(statement).scalar_one_or_none()
+
+
 def create_chat_log(
     db: Session,
     *,
@@ -61,5 +66,4 @@ def touch_chat_session_activity(db: Session, chat_session: ChatSession) -> ChatS
     chat_session.total_turns += 1
     chat_session.last_activity_at = get_current_utc_time()
     db.flush()
-    db.refresh(chat_session)
     return chat_session

--- a/app/repositories/chat_log_repository.py
+++ b/app/repositories/chat_log_repository.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.chat_enums import ChatAnswerStatus
+from app.db.models.chat_log import ChatLog
+from app.db.models.chat_session import ChatSession
+
+
+def get_chat_session(db: Session, session_id: str) -> Optional[ChatSession]:
+    statement = select(ChatSession).where(ChatSession.session_id == session_id)
+    return db.execute(statement).scalar_one_or_none()
+
+
+def create_chat_log(
+    db: Session,
+    *,
+    session_id: str,
+    user_id: Optional[int],
+    question: str,
+) -> ChatLog:
+    chat_log = ChatLog(
+        session_id=session_id,
+        user_id=user_id,
+        question=question,
+        answer_status=ChatAnswerStatus.PROCESSING,
+    )
+    db.add(chat_log)
+    db.flush()
+    db.refresh(chat_log)
+    return chat_log
+
+
+def update_chat_log_result(
+    db: Session,
+    chat_log: ChatLog,
+    *,
+    answer_status: ChatAnswerStatus,
+    answer: str,
+    rewritten_query: Optional[str],
+    model_name: Optional[str],
+    prompt_version: Optional[str],
+    retrieval_version: Optional[str],
+    response_time: int,
+) -> ChatLog:
+    chat_log.answer_status = answer_status
+    chat_log.answer = answer
+    chat_log.rewritten_query = rewritten_query
+    chat_log.model_name = model_name
+    chat_log.prompt_version = prompt_version
+    chat_log.retrieval_version = retrieval_version
+    chat_log.response_time = response_time
+    db.flush()
+    db.refresh(chat_log)
+    return chat_log
+
+
+def touch_chat_session_activity(db: Session, chat_session: ChatSession) -> ChatSession:
+    chat_session.total_turns += 1
+    chat_session.last_activity_at = datetime.utcnow()
+    db.flush()
+    db.refresh(chat_session)
+    return chat_session

--- a/app/repositories/chat_log_repository.py
+++ b/app/repositories/chat_log_repository.py
@@ -1,9 +1,9 @@
-from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.time_utils import get_current_utc_time
 from app.db.models.chat_enums import ChatAnswerStatus
 from app.db.models.chat_log import ChatLog
 from app.db.models.chat_session import ChatSession
@@ -59,7 +59,7 @@ def update_chat_log_result(
 
 def touch_chat_session_activity(db: Session, chat_session: ChatSession) -> ChatSession:
     chat_session.total_turns += 1
-    chat_session.last_activity_at = datetime.utcnow()
+    chat_session.last_activity_at = get_current_utc_time()
     db.flush()
     db.refresh(chat_session)
     return chat_session

--- a/app/repositories/chat_retrieval_result_repository.py
+++ b/app/repositories/chat_retrieval_result_repository.py
@@ -12,11 +12,15 @@ def create_chat_retrieval_results(
     retrieval_method: str,
 ) -> list[ChatRetrievalResult]:
     created_items: list[ChatRetrievalResult] = []
+    seen_regulation_chunk_ids: set[int] = set()
 
     for rank, item in enumerate(retrieval_items, start=1):
         regulation_chunk_id = item.get("regulation_chunk_id")
         if regulation_chunk_id is None:
             continue
+        if regulation_chunk_id in seen_regulation_chunk_ids:
+            continue
+        seen_regulation_chunk_ids.add(regulation_chunk_id)
 
         retrieval_result = ChatRetrievalResult(
             chat_log_id=chat_log_id,

--- a/app/repositories/chat_retrieval_result_repository.py
+++ b/app/repositories/chat_retrieval_result_repository.py
@@ -1,0 +1,56 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.chat_retrieval_result import ChatRetrievalResult
+
+
+def create_chat_retrieval_results(
+    db: Session,
+    *,
+    chat_log_id: int,
+    retrieval_items: list[dict],
+    retrieval_method: str,
+) -> list[ChatRetrievalResult]:
+    created_items: list[ChatRetrievalResult] = []
+
+    for rank, item in enumerate(retrieval_items, start=1):
+        regulation_chunk_id = item.get("regulation_chunk_id")
+        if regulation_chunk_id is None:
+            continue
+
+        retrieval_result = ChatRetrievalResult(
+            chat_log_id=chat_log_id,
+            regulation_chunk_id=regulation_chunk_id,
+            document_id=item.get("document_id"),
+            document_version=item.get("document_version"),
+            chunk_id=item.get("chunk_id"),
+            retrieval_rank=rank,
+            retrieval_score=item.get("similarity"),
+            retrieval_method=retrieval_method,
+            used_in_answer=False,
+            selected_as_citation=False,
+        )
+        db.add(retrieval_result)
+        created_items.append(retrieval_result)
+
+    db.flush()
+    for retrieval_result in created_items:
+        db.refresh(retrieval_result)
+    return created_items
+
+
+def mark_chat_retrieval_results_used_in_answer(
+    db: Session,
+    *,
+    chat_log_id: int,
+) -> list[ChatRetrievalResult]:
+    statement = select(ChatRetrievalResult).where(ChatRetrievalResult.chat_log_id == chat_log_id)
+    retrieval_results = list(db.execute(statement).scalars().all())
+
+    for retrieval_result in retrieval_results:
+        retrieval_result.used_in_answer = True
+
+    db.flush()
+    for retrieval_result in retrieval_results:
+        db.refresh(retrieval_result)
+    return retrieval_results

--- a/app/repositories/chat_retrieval_result_repository.py
+++ b/app/repositories/chat_retrieval_result_repository.py
@@ -47,12 +47,20 @@ def mark_chat_retrieval_results_used_in_answer(
     db: Session,
     *,
     chat_log_id: int,
+    cited_regulation_chunk_ids: list[int],
 ) -> list[ChatRetrievalResult]:
     statement = select(ChatRetrievalResult).where(ChatRetrievalResult.chat_log_id == chat_log_id)
     retrieval_results = list(db.execute(statement).scalars().all())
+    citation_order_by_chunk_id = {
+        regulation_chunk_id: order
+        for order, regulation_chunk_id in enumerate(cited_regulation_chunk_ids, start=1)
+    }
 
     for retrieval_result in retrieval_results:
-        retrieval_result.used_in_answer = True
+        citation_order = citation_order_by_chunk_id.get(retrieval_result.regulation_chunk_id)
+        retrieval_result.used_in_answer = citation_order is not None
+        retrieval_result.selected_as_citation = citation_order is not None
+        retrieval_result.citation_order = citation_order
 
     db.flush()
     for retrieval_result in retrieval_results:

--- a/app/repositories/chat_retrieval_result_repository.py
+++ b/app/repositories/chat_retrieval_result_repository.py
@@ -38,8 +38,6 @@ def create_chat_retrieval_results(
         created_items.append(retrieval_result)
 
     db.flush()
-    for retrieval_result in created_items:
-        db.refresh(retrieval_result)
     return created_items
 
 
@@ -63,6 +61,4 @@ def mark_chat_retrieval_results_used_in_answer(
         retrieval_result.citation_order = citation_order
 
     db.flush()
-    for retrieval_result in retrieval_results:
-        db.refresh(retrieval_result)
     return retrieval_results

--- a/app/repositories/chat_session_repository.py
+++ b/app/repositories/chat_session_repository.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.time_utils import get_current_utc_time
 from app.db.models.chat_session import ChatSession
 
 
@@ -10,10 +11,13 @@ def create_chat_session(
     session_id: str,
     user_id: Optional[int],
 ) -> ChatSession:
+    current_time = get_current_utc_time()
     chat_session = ChatSession(
         session_id=session_id,
         user_id=user_id,
         total_turns=0,
+        started_at=current_time,
+        last_activity_at=current_time,
     )
     db.add(chat_session)
     db.flush()

--- a/app/repositories/regulation_chunk_repository.py
+++ b/app/repositories/regulation_chunk_repository.py
@@ -2,8 +2,10 @@
 
 import hashlib
 from datetime import datetime
+from datetime import timezone
 from uuid import uuid4
 
+from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy import text
@@ -22,7 +24,7 @@ def create_regulation_chunks_for_document(
 ) -> list[RegulationChunk]:
     settings = get_settings()
     created_chunks: list[RegulationChunk] = []
-    ingestion_suffix = datetime.utcnow().strftime("%Y%m%d%H%M%S") + uuid4().hex[:8]
+    ingestion_suffix = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S") + uuid4().hex[:8]
 
     for index, (chunk_text, embedding) in enumerate(zip(chunk_texts, embeddings), start=1):
         chunk_id = (
@@ -64,10 +66,10 @@ def deactivate_chunks_for_document(db: Session, regulation_document_id: int) -> 
 
 
 def count_chunks_for_document(db: Session, regulation_document_id: int) -> int:
-    statement = select(RegulationChunk.regulation_chunk_id).where(
+    statement = select(func.count()).select_from(RegulationChunk).where(
         RegulationChunk.regulation_document_id == regulation_document_id
     )
-    return len(list(db.execute(statement).scalars().all()))
+    return db.execute(statement).scalar() or 0
 
 
 def deactivate_chunks_for_documents(db: Session, regulation_document_ids: list[int]) -> int:

--- a/app/repositories/regulation_chunk_repository.py
+++ b/app/repositories/regulation_chunk_repository.py
@@ -98,6 +98,9 @@ def search_similar_chunks(
     sql = text(
         """
         SELECT
+            rc.regulation_chunk_id,
+            rd.document_id,
+            rd.document_version,
             rc.chunk_id,
             COALESCE(rc.chunk_text, rd.content, '') AS content,
             rd.source_url,
@@ -125,6 +128,9 @@ def search_similar_chunks(
 
     return [
         {
+            "regulation_chunk_id": row.regulation_chunk_id,
+            "document_id": row.document_id,
+            "document_version": row.document_version,
             "chunk_id": row.chunk_id,
             "content": row.content,
             "source_url": row.source_url,

--- a/app/schemas/admin_chat.py
+++ b/app/schemas/admin_chat.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel
+from pydantic import Field
 
 
 class AdminChatLogDetail(BaseModel):
@@ -17,7 +18,8 @@ class AdminChatLogDetail(BaseModel):
     retrieval_version: Optional[str] = None
     response_time: Optional[int] = None
     created_at: datetime
-    retrieval_results: list["AdminChatRetrievalResult"] = []
+    retrieval_results: list["AdminChatRetrievalResult"] = Field(default_factory=list)
+    error_logs: list["AdminChatErrorLog"] = Field(default_factory=list)
 
 
 class AdminChatRetrievalResult(BaseModel):
@@ -33,6 +35,15 @@ class AdminChatRetrievalResult(BaseModel):
     used_in_answer: bool
     selected_as_citation: bool
     citation_order: Optional[int] = None
+    created_at: datetime
+
+
+class AdminChatErrorLog(BaseModel):
+    error_id: int
+    error_type: str
+    error_message: str
+    error_detail: Optional[str] = None
+    occurred_step: Optional[str] = None
     created_at: datetime
 
 

--- a/app/schemas/admin_chat.py
+++ b/app/schemas/admin_chat.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AdminChatLogDetail(BaseModel):
+    chat_log_id: int
+    session_id: str
+    user_id: Optional[int] = None
+    question: str
+    rewritten_query: Optional[str] = None
+    answer: Optional[str] = None
+    answer_status: str
+    model_name: Optional[str] = None
+    prompt_version: Optional[str] = None
+    retrieval_version: Optional[str] = None
+    response_time: Optional[int] = None
+    created_at: datetime
+    retrieval_results: list["AdminChatRetrievalResult"] = []
+
+
+class AdminChatRetrievalResult(BaseModel):
+    chat_retrieval_result_id: int
+    regulation_chunk_id: int
+    document_id: Optional[str] = None
+    document_version: Optional[str] = None
+    chunk_id: Optional[str] = None
+    retrieval_rank: Optional[int] = None
+    retrieval_score: Optional[float] = None
+    rerank_score: Optional[float] = None
+    retrieval_method: Optional[str] = None
+    used_in_answer: bool
+    selected_as_citation: bool
+    citation_order: Optional[int] = None
+    created_at: datetime
+
+
+class AdminChatSessionSummary(BaseModel):
+    session_id: str
+    user_id: Optional[int] = None
+    total_turns: int
+    started_at: datetime
+    last_activity_at: datetime
+
+
+class AdminRecentChatSessionsResult(BaseModel):
+    items: list[AdminChatSessionSummary]

--- a/app/schemas/admin_chat.py
+++ b/app/schemas/admin_chat.py
@@ -42,6 +42,7 @@ class AdminChatSessionSummary(BaseModel):
     total_turns: int
     started_at: datetime
     last_activity_at: datetime
+    is_expired: bool
 
 
 class AdminRecentChatSessionsResult(BaseModel):

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,5 +1,8 @@
-from pydantic import BaseModel
 from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel
+from pydantic import Field
 
 class ChatRequest(BaseModel):
     question: str
@@ -9,3 +12,15 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     answer: str
     source_url: str
+
+
+class ChatSessionCreateRequest(BaseModel):
+    user_id: Optional[int] = Field(default=None, ge=1)
+
+
+class ChatSessionCreateResponse(BaseModel):
+    session_id: str
+    user_id: Optional[int] = None
+    total_turns: int
+    started_at: datetime
+    last_activity_at: datetime

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -4,13 +4,18 @@ from datetime import datetime
 from pydantic import BaseModel
 from pydantic import Field
 
+
 class ChatRequest(BaseModel):
+    session_id: str = Field(min_length=1, max_length=100)
     question: str
     dormitory: Optional[str] = None
 
 
 class ChatResponse(BaseModel):
+    chat_log_id: int
+    session_id: str
     answer: str
+    answer_status: str
     source_url: str
 
 

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -1,7 +1,12 @@
+from datetime import datetime
+from datetime import timedelta
+
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
+from app.core.time_utils import get_current_utc_time
 from app.repositories.admin_chat_repository import get_chat_log_by_id
 from app.repositories.admin_chat_repository import list_chat_retrieval_results_by_chat_log_id
 from app.repositories.admin_chat_repository import list_recent_chat_sessions
@@ -61,7 +66,14 @@ def get_recent_admin_chat_sessions(db: Session) -> AdminRecentChatSessionsResult
                 total_turns=session.total_turns,
                 started_at=session.started_at,
                 last_activity_at=session.last_activity_at,
+                is_expired=_is_chat_session_expired(session.last_activity_at),
             )
             for session in sessions
         ]
     )
+
+
+def _is_chat_session_expired(last_activity_at: datetime) -> bool:
+    settings = get_settings()
+    expiration_threshold = get_current_utc_time() - timedelta(minutes=settings.chat_session_timeout_minutes)
+    return last_activity_at < expiration_threshold

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -8,8 +8,10 @@ from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
 from app.core.time_utils import get_current_utc_time
 from app.repositories.admin_chat_repository import get_chat_log_by_id
+from app.repositories.admin_chat_repository import list_chat_error_logs_by_chat_log_id
 from app.repositories.admin_chat_repository import list_chat_retrieval_results_by_chat_log_id
 from app.repositories.admin_chat_repository import list_recent_chat_sessions
+from app.schemas.admin_chat import AdminChatErrorLog
 from app.schemas.admin_chat import AdminChatLogDetail
 from app.schemas.admin_chat import AdminChatRetrievalResult
 from app.schemas.admin_chat import AdminRecentChatSessionsResult
@@ -21,6 +23,7 @@ def get_admin_chat_log_detail(db: Session, chat_log_id: int) -> AdminChatLogDeta
     if chat_log is None:
         raise AppException(CHAT_LOG_NOT_FOUND)
     retrieval_results = list_chat_retrieval_results_by_chat_log_id(db, chat_log_id)
+    error_logs = list_chat_error_logs_by_chat_log_id(db, chat_log_id)
 
     return AdminChatLogDetail(
         chat_log_id=chat_log.chat_log_id,
@@ -52,6 +55,17 @@ def get_admin_chat_log_detail(db: Session, chat_log_id: int) -> AdminChatLogDeta
                 created_at=item.created_at,
             )
             for item in retrieval_results
+        ],
+        error_logs=[
+            AdminChatErrorLog(
+                error_id=item.error_id,
+                error_type=item.error_type,
+                error_message=item.error_message,
+                error_detail=item.error_detail,
+                occurred_step=item.occurred_step,
+                created_at=item.created_at,
+            )
+            for item in error_logs
         ],
     )
 

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -1,0 +1,67 @@
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import CHAT_LOG_NOT_FOUND
+from app.core.exceptions import AppException
+from app.repositories.admin_chat_repository import get_chat_log_by_id
+from app.repositories.admin_chat_repository import list_chat_retrieval_results_by_chat_log_id
+from app.repositories.admin_chat_repository import list_recent_chat_sessions
+from app.schemas.admin_chat import AdminChatLogDetail
+from app.schemas.admin_chat import AdminChatRetrievalResult
+from app.schemas.admin_chat import AdminRecentChatSessionsResult
+from app.schemas.admin_chat import AdminChatSessionSummary
+
+
+def get_admin_chat_log_detail(db: Session, chat_log_id: int) -> AdminChatLogDetail:
+    chat_log = get_chat_log_by_id(db, chat_log_id)
+    if chat_log is None:
+        raise AppException(CHAT_LOG_NOT_FOUND)
+    retrieval_results = list_chat_retrieval_results_by_chat_log_id(db, chat_log_id)
+
+    return AdminChatLogDetail(
+        chat_log_id=chat_log.chat_log_id,
+        session_id=chat_log.session_id,
+        user_id=chat_log.user_id,
+        question=chat_log.question,
+        rewritten_query=chat_log.rewritten_query,
+        answer=chat_log.answer,
+        answer_status=chat_log.answer_status.value,
+        model_name=chat_log.model_name,
+        prompt_version=chat_log.prompt_version,
+        retrieval_version=chat_log.retrieval_version,
+        response_time=chat_log.response_time,
+        created_at=chat_log.created_at,
+        retrieval_results=[
+            AdminChatRetrievalResult(
+                chat_retrieval_result_id=item.chat_retrieval_result_id,
+                regulation_chunk_id=item.regulation_chunk_id,
+                document_id=item.document_id,
+                document_version=item.document_version,
+                chunk_id=item.chunk_id,
+                retrieval_rank=item.retrieval_rank,
+                retrieval_score=float(item.retrieval_score) if item.retrieval_score is not None else None,
+                rerank_score=float(item.rerank_score) if item.rerank_score is not None else None,
+                retrieval_method=item.retrieval_method,
+                used_in_answer=item.used_in_answer,
+                selected_as_citation=item.selected_as_citation,
+                citation_order=item.citation_order,
+                created_at=item.created_at,
+            )
+            for item in retrieval_results
+        ],
+    )
+
+
+def get_recent_admin_chat_sessions(db: Session) -> AdminRecentChatSessionsResult:
+    sessions = list_recent_chat_sessions(db, limit=10)
+    return AdminRecentChatSessionsResult(
+        items=[
+            AdminChatSessionSummary(
+                session_id=session.session_id,
+                user_id=session.user_id,
+                total_turns=session.total_turns,
+                started_at=session.started_at,
+                last_activity_at=session.last_activity_at,
+            )
+            for session in sessions
+        ]
+    )

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 from time import perf_counter
@@ -11,12 +12,13 @@ from app.core.error_codes import CHAT_SESSION_NOT_FOUND
 from app.core.exceptions import AppException
 from app.core.time_utils import get_current_utc_time
 from app.db.models.chat_enums import ChatAnswerStatus
+from app.repositories.chat_error_log_repository import create_chat_error_log
 from app.repositories.chat_log_repository import create_chat_log
-from app.repositories.chat_retrieval_result_repository import create_chat_retrieval_results
-from app.repositories.chat_retrieval_result_repository import mark_chat_retrieval_results_used_in_answer
 from app.repositories.chat_log_repository import get_chat_session
 from app.repositories.chat_log_repository import touch_chat_session_activity
 from app.repositories.chat_log_repository import update_chat_log_result
+from app.repositories.chat_retrieval_result_repository import create_chat_retrieval_results
+from app.repositories.chat_retrieval_result_repository import mark_chat_retrieval_results_used_in_answer
 from app.repositories.regulation_chunk_repository import search_similar_chunks
 from app.schemas.chat import ChatRequest
 from app.schemas.chat import ChatResponse
@@ -26,14 +28,36 @@ from app.services.generator import generate_grouped_answer
 from app.services.validator import validate_question
 
 ANSWER_MODEL_NAME = "gpt-4o-mini"
-PROMPT_VERSION_SINGLE = "chat-answer-v1"
-PROMPT_VERSION_GROUPED = "chat-answer-grouped-v1"
+PROMPT_VERSION_SINGLE = "chat-answer-citation-v1"
+PROMPT_VERSION_GROUPED = "chat-answer-grouped-citation-v1"
 RETRIEVAL_VERSION_SINGLE = "dormitory-search-v1"
 RETRIEVAL_VERSION_GROUPED = "dormitory-search-grouped-v1"
 RETRIEVAL_METHOD_SINGLE = "vector_dormitory_top_k"
 RETRIEVAL_METHOD_GROUPED = "vector_grouped_dormitory_top_k"
 NO_ANSWER_MESSAGE = "관련 정보를 찾을 수 없습니다."
 INVALID_QUESTION_MESSAGE = "기숙사 관련 질문을 입력해주세요."
+
+ERROR_TYPE_TIMEOUT = "TIMEOUT"
+ERROR_TYPE_LLM_API = "LLM_API_ERROR"
+ERROR_TYPE_RETRIEVAL = "RETRIEVAL_ERROR"
+ERROR_TYPE_PROMPT_BUILD = "PROMPT_BUILD_ERROR"
+ERROR_TYPE_VALIDATION = "VALIDATION_ERROR"
+ERROR_TYPE_UNKNOWN = "UNKNOWN_ERROR"
+
+STEP_QUESTION_VALIDATION = "QUESTION_VALIDATION"
+STEP_QUERY_REWRITE = "QUERY_REWRITE"
+STEP_RETRIEVAL = "RETRIEVAL"
+STEP_RERANK = "RERANK"
+STEP_ANSWER_GENERATION = "ANSWER_GENERATION"
+STEP_RESPONSE_RENDERING = "RESPONSE_RENDERING"
+
+
+@dataclass(frozen=True)
+class ChatErrorMetadata:
+    error_type: str
+    occurred_step: Optional[str]
+    error_message: str
+    error_detail: Optional[str]
 
 
 def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
@@ -60,7 +84,15 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
     normalized_question = None
 
     try:
-        is_valid, normalized_question = validate_question(payload.question)
+        try:
+            is_valid, normalized_question = validate_question(payload.question)
+        except Exception as exc:
+            _attach_chat_error_metadata(
+                exc,
+                error_type=ERROR_TYPE_VALIDATION,
+                occurred_step=STEP_QUESTION_VALIDATION,
+            )
+            raise
 
         if not is_valid:
             return _finalize_chat_log(
@@ -94,7 +126,8 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
             question=normalized_question,
             started_at=started_at,
         )
-    except Exception:
+    except Exception as exc:
+        error_metadata = _build_chat_error_metadata(exc)
         db.rollback()
         _finalize_chat_log(
             db,
@@ -108,6 +141,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
             prompt_version=None,
             retrieval_version=None,
             response_time_ms=_elapsed_ms(started_at),
+            error_metadata=error_metadata,
         )
         raise
 
@@ -121,13 +155,21 @@ def _answer_single_dormitory_chat(
     dormitory: str,
     started_at: float,
 ) -> ChatResponse:
-    query_embedding = create_query_embedding(question)
-    chunks = search_similar_chunks(
-        db=db,
-        query_embedding=query_embedding,
-        dormitory=dormitory,
-        top_k=3,
-    )
+    try:
+        query_embedding = create_query_embedding(question)
+        chunks = search_similar_chunks(
+            db=db,
+            query_embedding=query_embedding,
+            dormitory=dormitory,
+            top_k=3,
+        )
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
+        )
+        raise
 
     if not chunks:
         return _finalize_chat_log(
@@ -144,26 +186,44 @@ def _answer_single_dormitory_chat(
             response_time_ms=_elapsed_ms(started_at),
         )
 
-    create_chat_retrieval_results(
-        db,
-        chat_log_id=chat_log.chat_log_id,
-        retrieval_items=chunks,
-        retrieval_method=RETRIEVAL_METHOD_SINGLE,
-    )
-    answer, source_url = generate_answer(question, chunks)
+    labeled_chunks = _assign_citation_labels(chunks)
+    try:
+        create_chat_retrieval_results(
+            db,
+            chat_log_id=chat_log.chat_log_id,
+            retrieval_items=labeled_chunks,
+            retrieval_method=RETRIEVAL_METHOD_SINGLE,
+        )
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
+        )
+        raise
+    try:
+        answer_result = generate_answer(question, labeled_chunks)
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_LLM_API,
+            occurred_step=STEP_ANSWER_GENERATION,
+        )
+        raise
     return _finalize_chat_log(
         db,
         chat_log=chat_log,
         session_id=session_id,
         answer_status=ChatAnswerStatus.SUCCESS,
-        answer=answer,
-        source_url=source_url or "",
+        answer=answer_result.answer,
+        source_url=answer_result.source_url or "",
         rewritten_query=question,
         model_name=ANSWER_MODEL_NAME,
         prompt_version=PROMPT_VERSION_SINGLE,
         retrieval_version=RETRIEVAL_VERSION_SINGLE,
         response_time_ms=_elapsed_ms(started_at),
         mark_retrieval_used=True,
+        cited_regulation_chunk_ids=answer_result.cited_regulation_chunk_ids,
     )
 
 
@@ -175,17 +235,33 @@ def _answer_grouped_chat(
     question: str,
     started_at: float,
 ) -> ChatResponse:
-    query_embedding = create_query_embedding(question)
+    try:
+        query_embedding = create_query_embedding(question)
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
+        )
+        raise
     dormitories = ["제1학생생활관", "제2학생생활관", "제3학생생활관"]
     dormitory_chunks: dict[str, list[dict]] = {}
 
-    for dormitory in dormitories:
-        dormitory_chunks[dormitory] = search_similar_chunks(
-            db=db,
-            query_embedding=query_embedding,
-            dormitory=dormitory,
-            top_k=2,
+    try:
+        for dormitory in dormitories:
+            dormitory_chunks[dormitory] = search_similar_chunks(
+                db=db,
+                query_embedding=query_embedding,
+                dormitory=dormitory,
+                top_k=2,
+            )
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
         )
+        raise
 
     if not any(dormitory_chunks.values()):
         return _finalize_chat_log(
@@ -202,27 +278,45 @@ def _answer_grouped_chat(
             response_time_ms=_elapsed_ms(started_at),
         )
 
-    flattened_chunks = _flatten_grouped_retrieval_items(dormitory_chunks)
-    create_chat_retrieval_results(
-        db,
-        chat_log_id=chat_log.chat_log_id,
-        retrieval_items=flattened_chunks,
-        retrieval_method=RETRIEVAL_METHOD_GROUPED,
-    )
-    answer, source_url = generate_grouped_answer(question, dormitory_chunks)
+    flattened_chunks = _assign_citation_labels(_flatten_grouped_retrieval_items(dormitory_chunks))
+    grouped_labeled_chunks = _group_retrieval_items_by_group(flattened_chunks)
+    try:
+        create_chat_retrieval_results(
+            db,
+            chat_log_id=chat_log.chat_log_id,
+            retrieval_items=flattened_chunks,
+            retrieval_method=RETRIEVAL_METHOD_GROUPED,
+        )
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
+        )
+        raise
+    try:
+        answer_result = generate_grouped_answer(question, grouped_labeled_chunks)
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_LLM_API,
+            occurred_step=STEP_ANSWER_GENERATION,
+        )
+        raise
     return _finalize_chat_log(
         db,
         chat_log=chat_log,
         session_id=session_id,
         answer_status=ChatAnswerStatus.SUCCESS,
-        answer=answer,
-        source_url=source_url or "",
+        answer=answer_result.answer,
+        source_url=answer_result.source_url or "",
         rewritten_query=question,
         model_name=ANSWER_MODEL_NAME,
         prompt_version=PROMPT_VERSION_GROUPED,
         retrieval_version=RETRIEVAL_VERSION_GROUPED,
         response_time_ms=_elapsed_ms(started_at),
         mark_retrieval_used=True,
+        cited_regulation_chunk_ids=answer_result.cited_regulation_chunk_ids,
     )
 
 
@@ -240,12 +334,23 @@ def _finalize_chat_log(
     retrieval_version: Optional[str],
     response_time_ms: int,
     mark_retrieval_used: bool = False,
+    cited_regulation_chunk_ids: Optional[list[int]] = None,
+    error_metadata: Optional[ChatErrorMetadata] = None,
 ) -> ChatResponse:
     if mark_retrieval_used:
-        mark_chat_retrieval_results_used_in_answer(
-            db,
-            chat_log_id=chat_log.chat_log_id,
-        )
+        try:
+            mark_chat_retrieval_results_used_in_answer(
+                db,
+                chat_log_id=chat_log.chat_log_id,
+                cited_regulation_chunk_ids=cited_regulation_chunk_ids or [],
+            )
+        except Exception as exc:
+            _attach_chat_error_metadata(
+                exc,
+                error_type=ERROR_TYPE_PROMPT_BUILD,
+                occurred_step=STEP_RESPONSE_RENDERING,
+            )
+            raise
     update_chat_log_result(
         db,
         chat_log,
@@ -257,6 +362,16 @@ def _finalize_chat_log(
         retrieval_version=retrieval_version,
         response_time=response_time_ms,
     )
+    if error_metadata is not None:
+        create_chat_error_log(
+            db,
+            chat_log_id=chat_log.chat_log_id,
+            session_id=session_id,
+            error_type=error_metadata.error_type,
+            error_message=error_metadata.error_message,
+            error_detail=error_metadata.error_detail,
+            occurred_step=error_metadata.occurred_step,
+        )
     db.commit()
     db.refresh(chat_log)
 
@@ -305,4 +420,54 @@ def _flatten_grouped_retrieval_items(dormitory_chunks: dict[str, list[dict]]) ->
         deduplicated_items.values(),
         key=lambda item: item.get("similarity", 0.0),
         reverse=True,
+    )
+
+
+def _assign_citation_labels(retrieval_items: list[dict]) -> list[dict]:
+    labeled_items: list[dict] = []
+    for index, item in enumerate(retrieval_items, start=1):
+        labeled_item = dict(item)
+        labeled_item["citation_label"] = f"C{index}"
+        labeled_items.append(labeled_item)
+    return labeled_items
+
+
+def _group_retrieval_items_by_group(retrieval_items: list[dict]) -> dict[str, list[dict]]:
+    grouped_items: dict[str, list[dict]] = {}
+    for item in retrieval_items:
+        retrieval_group = item.get("retrieval_group")
+        if retrieval_group is None:
+            continue
+        grouped_items.setdefault(retrieval_group, []).append(item)
+    return grouped_items
+
+
+def _attach_chat_error_metadata(
+    exc: Exception,
+    *,
+    error_type: str,
+    occurred_step: Optional[str],
+) -> None:
+    setattr(exc, "_chat_error_type", error_type)
+    setattr(exc, "_chat_occurred_step", occurred_step)
+
+
+def _build_chat_error_metadata(exc: Exception) -> ChatErrorMetadata:
+    error_type = getattr(exc, "_chat_error_type", None)
+    occurred_step = getattr(exc, "_chat_occurred_step", None)
+
+    if error_type is None:
+        if isinstance(exc, TimeoutError):
+            error_type = ERROR_TYPE_TIMEOUT
+        else:
+            error_type = ERROR_TYPE_UNKNOWN
+
+    error_message = str(exc).strip() or type(exc).__name__
+    error_detail = f"{type(exc).__name__}: {error_message}"
+
+    return ChatErrorMetadata(
+        error_type=error_type,
+        occurred_step=occurred_step,
+        error_message=error_message,
+        error_detail=error_detail,
     )

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -1,0 +1,296 @@
+from datetime import datetime
+from datetime import timedelta
+from time import perf_counter
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import get_settings
+from app.core.error_codes import CHAT_SESSION_EXPIRED
+from app.core.error_codes import CHAT_SESSION_NOT_FOUND
+from app.core.exceptions import AppException
+from app.db.models.chat_enums import ChatAnswerStatus
+from app.repositories.chat_log_repository import create_chat_log
+from app.repositories.chat_retrieval_result_repository import create_chat_retrieval_results
+from app.repositories.chat_retrieval_result_repository import mark_chat_retrieval_results_used_in_answer
+from app.repositories.chat_log_repository import get_chat_session
+from app.repositories.chat_log_repository import touch_chat_session_activity
+from app.repositories.chat_log_repository import update_chat_log_result
+from app.repositories.regulation_chunk_repository import search_similar_chunks
+from app.schemas.chat import ChatRequest
+from app.schemas.chat import ChatResponse
+from app.services.embeddings import create_query_embedding
+from app.services.generator import generate_answer
+from app.services.generator import generate_grouped_answer
+from app.services.validator import validate_question
+
+ANSWER_MODEL_NAME = "gpt-4o-mini"
+PROMPT_VERSION_SINGLE = "chat-answer-v1"
+PROMPT_VERSION_GROUPED = "chat-answer-grouped-v1"
+RETRIEVAL_VERSION_SINGLE = "dormitory-search-v1"
+RETRIEVAL_VERSION_GROUPED = "dormitory-search-grouped-v1"
+RETRIEVAL_METHOD_SINGLE = "vector_dormitory_top_k"
+RETRIEVAL_METHOD_GROUPED = "vector_grouped_dormitory_top_k"
+NO_ANSWER_MESSAGE = "관련 정보를 찾을 수 없습니다."
+INVALID_QUESTION_MESSAGE = "기숙사 관련 질문을 입력해주세요."
+
+
+def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
+    chat_session = get_chat_session(db, payload.session_id)
+    if chat_session is None:
+        raise AppException(CHAT_SESSION_NOT_FOUND)
+    if _is_chat_session_expired(chat_session.last_activity_at):
+        raise AppException(
+            CHAT_SESSION_EXPIRED,
+            detail=_build_chat_session_expired_message(),
+        )
+
+    chat_log = create_chat_log(
+        db,
+        session_id=chat_session.session_id,
+        user_id=chat_session.user_id,
+        question=payload.question,
+    )
+    touch_chat_session_activity(db, chat_session)
+    db.commit()
+    db.refresh(chat_log)
+
+    started_at = perf_counter()
+    normalized_question = None
+
+    try:
+        is_valid, normalized_question = validate_question(payload.question)
+
+        if not is_valid:
+            return _finalize_chat_log(
+                db,
+                chat_log=chat_log,
+                session_id=payload.session_id,
+                answer_status=ChatAnswerStatus.NO_ANSWER,
+                answer=INVALID_QUESTION_MESSAGE,
+                source_url="",
+                rewritten_query=normalized_question,
+                model_name=None,
+                prompt_version=None,
+                retrieval_version=None,
+                response_time_ms=_elapsed_ms(started_at),
+            )
+
+        if payload.dormitory:
+            return _answer_single_dormitory_chat(
+                db,
+                chat_log=chat_log,
+                session_id=payload.session_id,
+                question=normalized_question,
+                dormitory=payload.dormitory,
+                started_at=started_at,
+            )
+
+        return _answer_grouped_chat(
+            db,
+            chat_log=chat_log,
+            session_id=payload.session_id,
+            question=normalized_question,
+            started_at=started_at,
+        )
+    except Exception:
+        db.rollback()
+        _finalize_chat_log(
+            db,
+            chat_log=chat_log,
+            session_id=payload.session_id,
+            answer_status=ChatAnswerStatus.ERROR,
+            answer="",
+            source_url="",
+            rewritten_query=normalized_question,
+            model_name=None,
+            prompt_version=None,
+            retrieval_version=None,
+            response_time_ms=_elapsed_ms(started_at),
+        )
+        raise
+
+
+def _answer_single_dormitory_chat(
+    db: Session,
+    *,
+    chat_log,
+    session_id: str,
+    question: str,
+    dormitory: str,
+    started_at: float,
+) -> ChatResponse:
+    query_embedding = create_query_embedding(question)
+    chunks = search_similar_chunks(
+        db=db,
+        query_embedding=query_embedding,
+        dormitory=dormitory,
+        top_k=3,
+    )
+
+    if not chunks:
+        return _finalize_chat_log(
+            db,
+            chat_log=chat_log,
+            session_id=session_id,
+            answer_status=ChatAnswerStatus.NO_ANSWER,
+            answer=NO_ANSWER_MESSAGE,
+            source_url="",
+            rewritten_query=question,
+            model_name=None,
+            prompt_version=None,
+            retrieval_version=RETRIEVAL_VERSION_SINGLE,
+            response_time_ms=_elapsed_ms(started_at),
+        )
+
+    create_chat_retrieval_results(
+        db,
+        chat_log_id=chat_log.chat_log_id,
+        retrieval_items=chunks,
+        retrieval_method=RETRIEVAL_METHOD_SINGLE,
+    )
+    answer, source_url = generate_answer(question, chunks)
+    return _finalize_chat_log(
+        db,
+        chat_log=chat_log,
+        session_id=session_id,
+        answer_status=ChatAnswerStatus.SUCCESS,
+        answer=answer,
+        source_url=source_url or "",
+        rewritten_query=question,
+        model_name=ANSWER_MODEL_NAME,
+        prompt_version=PROMPT_VERSION_SINGLE,
+        retrieval_version=RETRIEVAL_VERSION_SINGLE,
+        response_time_ms=_elapsed_ms(started_at),
+        mark_retrieval_used=True,
+    )
+
+
+def _answer_grouped_chat(
+    db: Session,
+    *,
+    chat_log,
+    session_id: str,
+    question: str,
+    started_at: float,
+) -> ChatResponse:
+    query_embedding = create_query_embedding(question)
+    dormitories = ["제1학생생활관", "제2학생생활관", "제3학생생활관"]
+    dormitory_chunks: dict[str, list[dict]] = {}
+
+    for dormitory in dormitories:
+        dormitory_chunks[dormitory] = search_similar_chunks(
+            db=db,
+            query_embedding=query_embedding,
+            dormitory=dormitory,
+            top_k=2,
+        )
+
+    if not any(dormitory_chunks.values()):
+        return _finalize_chat_log(
+            db,
+            chat_log=chat_log,
+            session_id=session_id,
+            answer_status=ChatAnswerStatus.NO_ANSWER,
+            answer=NO_ANSWER_MESSAGE,
+            source_url="",
+            rewritten_query=question,
+            model_name=None,
+            prompt_version=None,
+            retrieval_version=RETRIEVAL_VERSION_GROUPED,
+            response_time_ms=_elapsed_ms(started_at),
+        )
+
+    flattened_chunks = _flatten_grouped_retrieval_items(dormitory_chunks)
+    create_chat_retrieval_results(
+        db,
+        chat_log_id=chat_log.chat_log_id,
+        retrieval_items=flattened_chunks,
+        retrieval_method=RETRIEVAL_METHOD_GROUPED,
+    )
+    answer, source_url = generate_grouped_answer(question, dormitory_chunks)
+    return _finalize_chat_log(
+        db,
+        chat_log=chat_log,
+        session_id=session_id,
+        answer_status=ChatAnswerStatus.SUCCESS,
+        answer=answer,
+        source_url=source_url or "",
+        rewritten_query=question,
+        model_name=ANSWER_MODEL_NAME,
+        prompt_version=PROMPT_VERSION_GROUPED,
+        retrieval_version=RETRIEVAL_VERSION_GROUPED,
+        response_time_ms=_elapsed_ms(started_at),
+        mark_retrieval_used=True,
+    )
+
+
+def _finalize_chat_log(
+    db: Session,
+    *,
+    chat_log,
+    session_id: str,
+    answer_status: ChatAnswerStatus,
+    answer: str,
+    source_url: str,
+    rewritten_query: Optional[str],
+    model_name: Optional[str],
+    prompt_version: Optional[str],
+    retrieval_version: Optional[str],
+    response_time_ms: int,
+    mark_retrieval_used: bool = False,
+) -> ChatResponse:
+    if mark_retrieval_used:
+        mark_chat_retrieval_results_used_in_answer(
+            db,
+            chat_log_id=chat_log.chat_log_id,
+        )
+    update_chat_log_result(
+        db,
+        chat_log,
+        answer_status=answer_status,
+        answer=answer,
+        rewritten_query=rewritten_query,
+        model_name=model_name,
+        prompt_version=prompt_version,
+        retrieval_version=retrieval_version,
+        response_time=response_time_ms,
+    )
+    db.commit()
+    db.refresh(chat_log)
+
+    return ChatResponse(
+        chat_log_id=chat_log.chat_log_id,
+        session_id=session_id,
+        answer=answer,
+        answer_status=answer_status.value,
+        source_url=source_url,
+    )
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return max(int((perf_counter() - started_at) * 1000), 0)
+
+
+def _is_chat_session_expired(last_activity_at: datetime) -> bool:
+    settings = get_settings()
+    expiration_threshold = datetime.utcnow() - timedelta(minutes=settings.chat_session_timeout_minutes)
+    return last_activity_at < expiration_threshold
+
+
+def _build_chat_session_expired_message() -> str:
+    settings = get_settings()
+    return (
+        f"chat session expired after {settings.chat_session_timeout_minutes} minutes of inactivity. "
+        "please start a new chat session"
+    )
+
+
+def _flatten_grouped_retrieval_items(dormitory_chunks: dict[str, list[dict]]) -> list[dict]:
+    flattened_items: list[dict] = []
+    for dormitory, chunks in dormitory_chunks.items():
+        for chunk in chunks:
+            flattened_item = dict(chunk)
+            flattened_item["retrieval_group"] = dormitory
+            flattened_items.append(flattened_item)
+    return flattened_items

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -8,12 +8,15 @@ from sqlalchemy.orm import Session
 
 from app.core.config import get_settings
 from app.core.error_codes import CHAT_SESSION_EXPIRED
+from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.error_codes import CHAT_SESSION_NOT_FOUND
 from app.core.exceptions import AppException
 from app.core.time_utils import get_current_utc_time
 from app.db.models.chat_enums import ChatAnswerStatus
+from app.db.session import get_session_factory
 from app.repositories.chat_error_log_repository import create_chat_error_log
 from app.repositories.chat_log_repository import create_chat_log
+from app.repositories.chat_log_repository import get_chat_log_by_id
 from app.repositories.chat_log_repository import get_chat_session
 from app.repositories.chat_log_repository import touch_chat_session_activity
 from app.repositories.chat_log_repository import update_chat_log_result
@@ -82,6 +85,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
 
     started_at = perf_counter()
     normalized_question = None
+    chat_log_id = chat_log.chat_log_id
 
     try:
         try:
@@ -97,7 +101,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
         if not is_valid:
             return _finalize_chat_log(
                 db,
-                chat_log=chat_log,
+                chat_log_id=chat_log_id,
                 session_id=payload.session_id,
                 answer_status=ChatAnswerStatus.NO_ANSWER,
                 answer=INVALID_QUESTION_MESSAGE,
@@ -112,7 +116,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
         if payload.dormitory:
             return _answer_single_dormitory_chat(
                 db,
-                chat_log=chat_log,
+                chat_log_id=chat_log_id,
                 session_id=payload.session_id,
                 question=normalized_question,
                 dormitory=payload.dormitory,
@@ -121,7 +125,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
 
         return _answer_grouped_chat(
             db,
-            chat_log=chat_log,
+            chat_log_id=chat_log_id,
             session_id=payload.session_id,
             question=normalized_question,
             started_at=started_at,
@@ -129,9 +133,8 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
     except Exception as exc:
         error_metadata = _build_chat_error_metadata(exc)
         db.rollback()
-        _finalize_chat_log(
-            db,
-            chat_log=chat_log,
+        _finalize_chat_log_in_new_session(
+            chat_log_id=chat_log_id,
             session_id=payload.session_id,
             answer_status=ChatAnswerStatus.ERROR,
             answer="",
@@ -149,7 +152,7 @@ def answer_chat_question(db: Session, payload: ChatRequest) -> ChatResponse:
 def _answer_single_dormitory_chat(
     db: Session,
     *,
-    chat_log,
+    chat_log_id: int,
     session_id: str,
     question: str,
     dormitory: str,
@@ -174,7 +177,7 @@ def _answer_single_dormitory_chat(
     if not chunks:
         return _finalize_chat_log(
             db,
-            chat_log=chat_log,
+            chat_log_id=chat_log_id,
             session_id=session_id,
             answer_status=ChatAnswerStatus.NO_ANSWER,
             answer=NO_ANSWER_MESSAGE,
@@ -190,7 +193,7 @@ def _answer_single_dormitory_chat(
     try:
         create_chat_retrieval_results(
             db,
-            chat_log_id=chat_log.chat_log_id,
+            chat_log_id=chat_log_id,
             retrieval_items=labeled_chunks,
             retrieval_method=RETRIEVAL_METHOD_SINGLE,
         )
@@ -201,6 +204,8 @@ def _answer_single_dormitory_chat(
             occurred_step=STEP_RETRIEVAL,
         )
         raise
+    db.commit()
+    db.close()
     try:
         answer_result = generate_answer(question, labeled_chunks)
     except Exception as exc:
@@ -210,9 +215,8 @@ def _answer_single_dormitory_chat(
             occurred_step=STEP_ANSWER_GENERATION,
         )
         raise
-    return _finalize_chat_log(
-        db,
-        chat_log=chat_log,
+    return _finalize_chat_log_in_new_session(
+        chat_log_id=chat_log_id,
         session_id=session_id,
         answer_status=ChatAnswerStatus.SUCCESS,
         answer=answer_result.answer,
@@ -230,7 +234,7 @@ def _answer_single_dormitory_chat(
 def _answer_grouped_chat(
     db: Session,
     *,
-    chat_log,
+    chat_log_id: int,
     session_id: str,
     question: str,
     started_at: float,
@@ -266,7 +270,7 @@ def _answer_grouped_chat(
     if not any(dormitory_chunks.values()):
         return _finalize_chat_log(
             db,
-            chat_log=chat_log,
+            chat_log_id=chat_log_id,
             session_id=session_id,
             answer_status=ChatAnswerStatus.NO_ANSWER,
             answer=NO_ANSWER_MESSAGE,
@@ -283,7 +287,7 @@ def _answer_grouped_chat(
     try:
         create_chat_retrieval_results(
             db,
-            chat_log_id=chat_log.chat_log_id,
+            chat_log_id=chat_log_id,
             retrieval_items=flattened_chunks,
             retrieval_method=RETRIEVAL_METHOD_GROUPED,
         )
@@ -294,6 +298,8 @@ def _answer_grouped_chat(
             occurred_step=STEP_RETRIEVAL,
         )
         raise
+    db.commit()
+    db.close()
     try:
         answer_result = generate_grouped_answer(question, grouped_labeled_chunks)
     except Exception as exc:
@@ -303,9 +309,8 @@ def _answer_grouped_chat(
             occurred_step=STEP_ANSWER_GENERATION,
         )
         raise
-    return _finalize_chat_log(
-        db,
-        chat_log=chat_log,
+    return _finalize_chat_log_in_new_session(
+        chat_log_id=chat_log_id,
         session_id=session_id,
         answer_status=ChatAnswerStatus.SUCCESS,
         answer=answer_result.answer,
@@ -323,7 +328,7 @@ def _answer_grouped_chat(
 def _finalize_chat_log(
     db: Session,
     *,
-    chat_log,
+    chat_log_id: int,
     session_id: str,
     answer_status: ChatAnswerStatus,
     answer: str,
@@ -337,11 +342,15 @@ def _finalize_chat_log(
     cited_regulation_chunk_ids: Optional[list[int]] = None,
     error_metadata: Optional[ChatErrorMetadata] = None,
 ) -> ChatResponse:
+    chat_log = get_chat_log_by_id(db, chat_log_id)
+    if chat_log is None:
+        raise AppException(CHAT_LOG_NOT_FOUND)
+
     if mark_retrieval_used:
         try:
             mark_chat_retrieval_results_used_in_answer(
                 db,
-                chat_log_id=chat_log.chat_log_id,
+                chat_log_id=chat_log_id,
                 cited_regulation_chunk_ids=cited_regulation_chunk_ids or [],
             )
         except Exception as exc:
@@ -365,7 +374,7 @@ def _finalize_chat_log(
     if error_metadata is not None:
         create_chat_error_log(
             db,
-            chat_log_id=chat_log.chat_log_id,
+            chat_log_id=chat_log_id,
             session_id=session_id,
             error_type=error_metadata.error_type,
             error_message=error_metadata.error_message,
@@ -376,12 +385,51 @@ def _finalize_chat_log(
     db.refresh(chat_log)
 
     return ChatResponse(
-        chat_log_id=chat_log.chat_log_id,
+        chat_log_id=chat_log_id,
         session_id=session_id,
         answer=answer,
         answer_status=answer_status.value,
         source_url=source_url,
     )
+
+
+def _finalize_chat_log_in_new_session(
+    *,
+    chat_log_id: int,
+    session_id: str,
+    answer_status: ChatAnswerStatus,
+    answer: str,
+    source_url: str,
+    rewritten_query: Optional[str],
+    model_name: Optional[str],
+    prompt_version: Optional[str],
+    retrieval_version: Optional[str],
+    response_time_ms: int,
+    mark_retrieval_used: bool = False,
+    cited_regulation_chunk_ids: Optional[list[int]] = None,
+    error_metadata: Optional[ChatErrorMetadata] = None,
+) -> ChatResponse:
+    session_factory = get_session_factory()
+    finalize_db = session_factory()
+    try:
+        return _finalize_chat_log(
+            finalize_db,
+            chat_log_id=chat_log_id,
+            session_id=session_id,
+            answer_status=answer_status,
+            answer=answer,
+            source_url=source_url,
+            rewritten_query=rewritten_query,
+            model_name=model_name,
+            prompt_version=prompt_version,
+            retrieval_version=retrieval_version,
+            response_time_ms=response_time_ms,
+            mark_retrieval_used=mark_retrieval_used,
+            cited_regulation_chunk_ids=cited_regulation_chunk_ids,
+            error_metadata=error_metadata,
+        )
+    finally:
+        finalize_db.close()
 
 
 def _elapsed_ms(started_at: float) -> int:

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -9,6 +9,7 @@ from app.core.config import get_settings
 from app.core.error_codes import CHAT_SESSION_EXPIRED
 from app.core.error_codes import CHAT_SESSION_NOT_FOUND
 from app.core.exceptions import AppException
+from app.core.time_utils import get_current_utc_time
 from app.db.models.chat_enums import ChatAnswerStatus
 from app.repositories.chat_log_repository import create_chat_log
 from app.repositories.chat_retrieval_result_repository import create_chat_retrieval_results
@@ -274,7 +275,7 @@ def _elapsed_ms(started_at: float) -> int:
 
 def _is_chat_session_expired(last_activity_at: datetime) -> bool:
     settings = get_settings()
-    expiration_threshold = datetime.utcnow() - timedelta(minutes=settings.chat_session_timeout_minutes)
+    expiration_threshold = get_current_utc_time() - timedelta(minutes=settings.chat_session_timeout_minutes)
     return last_activity_at < expiration_threshold
 
 
@@ -287,10 +288,21 @@ def _build_chat_session_expired_message() -> str:
 
 
 def _flatten_grouped_retrieval_items(dormitory_chunks: dict[str, list[dict]]) -> list[dict]:
-    flattened_items: list[dict] = []
+    deduplicated_items: dict[int, dict] = {}
     for dormitory, chunks in dormitory_chunks.items():
         for chunk in chunks:
-            flattened_item = dict(chunk)
-            flattened_item["retrieval_group"] = dormitory
-            flattened_items.append(flattened_item)
-    return flattened_items
+            regulation_chunk_id = chunk.get("regulation_chunk_id")
+            if regulation_chunk_id is None:
+                continue
+
+            existing_item = deduplicated_items.get(regulation_chunk_id)
+            if existing_item is None or chunk.get("similarity", 0.0) > existing_item.get("similarity", 0.0):
+                flattened_item = dict(chunk)
+                flattened_item["retrieval_group"] = dormitory
+                deduplicated_items[regulation_chunk_id] = flattened_item
+
+    return sorted(
+        deduplicated_items.values(),
+        key=lambda item: item.get("similarity", 0.0),
+        reverse=True,
+    )

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -1,3 +1,5 @@
+import re
+from dataclasses import dataclass
 
 from app.core.config import get_settings
 from openai import OpenAI
@@ -6,20 +8,42 @@ settings = get_settings()
 client = OpenAI(api_key=settings.openai_api_key)
 
 
-def generate_answer(question: str, chunks: list[dict]) -> tuple[str, str]:
+NO_ANSWER_MESSAGE = "관련 정보를 찾을 수 없습니다."
+
+
+@dataclass(frozen=True)
+class AnswerGenerationResult:
+    answer: str
+    source_url: str
+    cited_regulation_chunk_ids: list[int]
+
+
+def generate_answer(question: str, chunks: list[dict]) -> AnswerGenerationResult:
     """
     검색된 chunk들을 기반으로 최종 답변 생성
     """
 
     if not chunks:
-        return "관련 정보를 찾을 수 없습니다.", ""
+        return AnswerGenerationResult(
+            answer=NO_ANSWER_MESSAGE,
+            source_url="",
+            cited_regulation_chunk_ids=[],
+        )
 
-    context = "\n\n".join([chunk["content"] for chunk in chunks])
+    context = "\n\n".join(
+        [
+            f"[{chunk['citation_label']}] {chunk['content']}"
+            for chunk in chunks
+        ]
+    )
 
     prompt = f"""
 너는 기숙사 안내 챗봇이다.
 아래 제공된 정보를 기반으로만 질문에 답변해라.
 모르는 내용은 추측하지 말고 모른다고 말해라.
+답변에서 참고한 근거가 있으면 문장 끝에 반드시 근거 라벨을 붙여라.
+근거 라벨은 제공된 형식 그대로 `[C1]`, `[C2]`처럼 사용해라.
+질문에 답할 정보가 충분하지 않으면 정확히 "{NO_ANSWER_MESSAGE}"라고만 답해라.
 
 [질문]
 {question}
@@ -37,30 +61,35 @@ def generate_answer(question: str, chunks: list[dict]) -> tuple[str, str]:
     )
 
     answer = response.choices[0].message.content.strip()
+    cited_regulation_chunk_ids = _extract_cited_regulation_chunk_ids(answer, chunks)
+    source_url = _resolve_source_url(chunks, cited_regulation_chunk_ids)
 
-    # 첫 번째 chunk의 source_url 사용
-    source_url = chunks[0].get("source_url", "")
+    return AnswerGenerationResult(
+        answer=answer,
+        source_url=source_url,
+        cited_regulation_chunk_ids=cited_regulation_chunk_ids,
+    )
 
-    return answer, source_url
 
-
-def generate_grouped_answer(question: str, dormitory_chunks: dict[str, list[dict]]) -> tuple[str, str]:
+def generate_grouped_answer(question: str, dormitory_chunks: dict[str, list[dict]]) -> AnswerGenerationResult:
     """
     dormitory가 없을 때 생활관별 검색 결과를 나눠서 답변 생성
     """
     available = {k: v for k, v in dormitory_chunks.items() if v}
 
     if not available:
-        return "관련 정보를 찾을 수 없습니다.", ""
+        return AnswerGenerationResult(
+            answer=NO_ANSWER_MESSAGE,
+            source_url="",
+            cited_regulation_chunk_ids=[],
+        )
 
     context_parts = []
-    first_source_url = ""
+    all_chunks: list[dict] = []
 
     for dormitory, chunks in available.items():
-        if not first_source_url and chunks:
-            first_source_url = chunks[0].get("source_url", "")
-
-        joined = "\n".join([f"- {chunk['content']}" for chunk in chunks])
+        all_chunks.extend(chunks)
+        joined = "\n".join([f"- [{chunk['citation_label']}] {chunk['content']}" for chunk in chunks])
         context_parts.append(f"[{dormitory}]\n{joined}")
 
     context = "\n\n".join(context_parts)
@@ -71,11 +100,13 @@ def generate_grouped_answer(question: str, dormitory_chunks: dict[str, list[dict
 반드시 생활관별로 구분해서 설명해라.
 정보가 없는 생활관은 언급하지 않아도 된다.
 모르는 내용은 추측하지 말고 제공된 정보 범위에서만 답변해라.
+각 생활관 설명 문장 끝에는 반드시 해당 근거 라벨 `[C1]`, `[C2]`를 붙여라.
+질문에 답할 정보가 충분하지 않으면 정확히 "{NO_ANSWER_MESSAGE}"라고만 답해라.
 
 출력 형식 예시:
-제1학생생활관: ...
-제2학생생활관: ...
-제3학생생활관: ...
+제1학생생활관: ... [C1]
+제2학생생활관: ... [C2]
+제3학생생활관: ... [C3]
 
 [질문]
 {question}
@@ -93,4 +124,44 @@ def generate_grouped_answer(question: str, dormitory_chunks: dict[str, list[dict
     )
 
     answer = response.choices[0].message.content.strip()
-    return answer, first_source_url
+    cited_regulation_chunk_ids = _extract_cited_regulation_chunk_ids(answer, all_chunks)
+    source_url = _resolve_source_url(all_chunks, cited_regulation_chunk_ids)
+    return AnswerGenerationResult(
+        answer=answer,
+        source_url=source_url,
+        cited_regulation_chunk_ids=cited_regulation_chunk_ids,
+    )
+
+
+def _extract_cited_regulation_chunk_ids(answer: str, chunks: list[dict]) -> list[int]:
+    citation_labels = re.findall(r"\[(C\d+)\]", answer)
+    if not citation_labels:
+        return []
+
+    label_to_chunk_id = {
+        chunk["citation_label"]: chunk["regulation_chunk_id"]
+        for chunk in chunks
+        if chunk.get("citation_label") and chunk.get("regulation_chunk_id") is not None
+    }
+
+    cited_regulation_chunk_ids: list[int] = []
+    seen_chunk_ids: set[int] = set()
+    for citation_label in citation_labels:
+        regulation_chunk_id = label_to_chunk_id.get(citation_label)
+        if regulation_chunk_id is None:
+            continue
+        if regulation_chunk_id in seen_chunk_ids:
+            continue
+        seen_chunk_ids.add(regulation_chunk_id)
+        cited_regulation_chunk_ids.append(regulation_chunk_id)
+
+    return cited_regulation_chunk_ids
+
+
+def _resolve_source_url(chunks: list[dict], cited_regulation_chunk_ids: list[int]) -> str:
+    if cited_regulation_chunk_ids:
+        cited_chunk_id = cited_regulation_chunk_ids[0]
+        for chunk in chunks:
+            if chunk.get("regulation_chunk_id") == cited_chunk_id:
+                return chunk.get("source_url", "") or ""
+    return chunks[0].get("source_url", "") or ""

--- a/app/services/regulation_document_service.py
+++ b/app/services/regulation_document_service.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.config import get_settings
 from app.core.error_codes import REGULATION_DOCUMENT_ALREADY_EXISTS
 from app.core.error_codes import REGULATION_DOCUMENT_CREATE_FAILED
 from app.core.error_codes import REGULATION_DOCUMENT_DELETE_FAILED
@@ -257,10 +258,11 @@ def _run_reingestion_event(db: Session, regulation_document) -> tuple[str, Optio
 
 
 def _chunk_document_content(regulation_document) -> list[str]:
+    settings = get_settings()
+    max_chunk_length = settings.regulation_chunk_max_length
     content = (regulation_document.content or "").strip()
-    title = (regulation_document.title or "").strip()
     if not content:
-        return [f"제목: {title}".strip()]
+        return [_build_chunk_text(regulation_document, "")]
 
     normalized_lines = [
         line.strip()
@@ -272,19 +274,46 @@ def _chunk_document_content(regulation_document) -> list[str]:
     chunks: list[str] = []
     buffer = ""
     for paragraph in paragraphs:
-        candidate = f"{buffer}\n{paragraph}".strip() if buffer else paragraph
-        if len(candidate) <= 800:
-            buffer = candidate
-            continue
+        paragraph_parts = _split_text_by_max_length(paragraph, max_chunk_length)
+        for paragraph_part in paragraph_parts:
+            candidate = f"{buffer}\n{paragraph_part}".strip() if buffer else paragraph_part
+            if len(candidate) <= max_chunk_length:
+                buffer = candidate
+                continue
 
-        if buffer:
-            chunks.append(_build_chunk_text(regulation_document, buffer))
-        buffer = paragraph
+            if buffer:
+                chunks.append(_build_chunk_text(regulation_document, buffer))
+            buffer = paragraph_part
+
+            if len(buffer) > max_chunk_length:
+                chunks.append(_build_chunk_text(regulation_document, buffer))
+                buffer = ""
 
     if buffer:
         chunks.append(_build_chunk_text(regulation_document, buffer))
 
     return chunks
+
+
+def _split_text_by_max_length(text: str, max_length: int) -> list[str]:
+    if len(text) <= max_length:
+        return [text]
+
+    parts: list[str] = []
+    remaining_text = text.strip()
+    while remaining_text:
+        if len(remaining_text) <= max_length:
+            parts.append(remaining_text)
+            break
+
+        split_index = remaining_text.rfind(" ", 0, max_length + 1)
+        if split_index <= 0:
+            split_index = max_length
+
+        parts.append(remaining_text[:split_index].strip())
+        remaining_text = remaining_text[split_index:].strip()
+
+    return parts
 
 
 def _build_chunk_text(regulation_document, content: str) -> str:

--- a/docs/chat-session-timeout-policy.md
+++ b/docs/chat-session-timeout-policy.md
@@ -1,0 +1,120 @@
+# Chat Session Timeout Policy
+
+## 개요
+
+채팅 세션은 `chat_session` 테이블에 저장되며, 각 질문은 `chat_log`로 기록됩니다.  
+현재 정책은 별도의 "대화 종료" 버튼 없이 `last_activity_at` 기준 비활성 시간을 계산해 세션 유효 여부를 판단합니다.
+
+기본 설정값:
+
+- `chat_session_timeout_minutes = 30`
+
+즉, 마지막 질문 처리 시각으로부터 30분 이상 추가 질문이 없으면 해당 세션은 만료된 것으로 간주합니다.
+
+## 정책 상세
+
+### 1. 세션 생성
+
+- `POST /api/v1/ai/chat/sessions`
+- 응답으로 `session_id`를 발급합니다.
+
+### 2. 세션 사용
+
+- `POST /api/v1/ai/chat`
+- 요청 바디에 `session_id`를 반드시 포함해야 합니다.
+- 서버는 `chat_session`을 조회한 뒤, 아래 순서로 검사합니다.
+
+검사 순서:
+
+1. `session_id`가 실제로 존재하는가
+2. `last_activity_at`이 현재 시각 기준 30분 이내인가
+3. 유효하면 `chat_log`를 `PROCESSING` 상태로 생성하고 답변 처리를 시작
+
+### 3. 세션 만료
+
+만료 조건:
+
+- `datetime.utcnow() - last_activity_at > 30분`
+
+만료된 세션에 대해서는:
+
+- 새 `chat_log`를 만들지 않습니다.
+- `chat_session.total_turns`를 증가시키지 않습니다.
+- `chat_session.last_activity_at`를 갱신하지 않습니다.
+- 클라이언트에 만료 에러를 반환합니다.
+
+### 4. 재시작 방식
+
+현재는 명시 종료 API가 없으므로, 만료된 세션은 재사용하지 않습니다.
+
+클라이언트 처리 권장 흐름:
+
+1. `/api/v1/ai/chat` 호출
+2. `CHAT_SESSION_EXPIRED` 응답 수신
+3. `/api/v1/ai/chat/sessions`로 새 세션 발급
+4. 새 `session_id`로 질문 재전송
+
+## 에러 코드
+
+### `CHAT_SESSION_NOT_FOUND`
+
+- HTTP Status: `404`
+- 의미: 요청에 포함된 `session_id`가 DB에 존재하지 않음
+- 예시 상황:
+  - 잘못된 세션 ID 전달
+  - 이미 다른 환경에서 사용하던 임의 값 전달
+
+예시 응답:
+
+```json
+{
+  "status": 404,
+  "message": "chat session not found",
+  "data": null,
+  "error_code": "CHAT_SESSION_NOT_FOUND"
+}
+```
+
+### `CHAT_SESSION_EXPIRED`
+
+- HTTP Status: `409`
+- 의미: 세션은 존재하지만 비활성 30분을 초과해 더 이상 사용할 수 없음
+- 예시 상황:
+  - 앱을 오래 켜두고 다시 질문한 경우
+  - 이전 대화를 복구하려다 만료된 `session_id`를 재사용한 경우
+
+예시 응답:
+
+```json
+{
+  "status": 409,
+  "message": "chat session expired after 30 minutes of inactivity. please start a new chat session",
+  "data": null,
+  "error_code": "CHAT_SESSION_EXPIRED"
+}
+```
+
+## 구현 메모
+
+- 설정 위치: [config.py](/Users/kimssirr/Documents/Playground/Gaon-i/app/core/config.py)
+- 만료 판단 위치: [chat_service.py](/Users/kimssirr/Documents/Playground/Gaon-i/app/services/chat_service.py)
+- 공통 에러 코드 위치: [error_codes.py](/Users/kimssirr/Documents/Playground/Gaon-i/app/core/error_codes.py)
+
+## 수동 테스트 시나리오
+
+### 정상 흐름
+
+1. `POST /api/v1/ai/chat/sessions` 호출
+2. 받은 `session_id`로 즉시 `POST /api/v1/ai/chat` 호출
+3. `SUCCESS` 또는 `NO_ANSWER` 응답 확인
+
+### 존재하지 않는 세션
+
+1. 임의의 `session_id`로 `POST /api/v1/ai/chat` 호출
+2. `404`, `CHAT_SESSION_NOT_FOUND` 응답 확인
+
+### 만료된 세션
+
+1. 세션 생성 후 `last_activity_at`를 강제로 30분 이전으로 조정
+2. 해당 `session_id`로 `POST /api/v1/ai/chat` 호출
+3. `409`, `CHAT_SESSION_EXPIRED` 응답 확인

--- a/docs/트러블슈팅.md
+++ b/docs/트러블슈팅.md
@@ -308,3 +308,133 @@ def get_current_kst_time() -> datetime:
 5. 교훈 및 주의 사항
 주의할 점: naive datetime을 쓸 때는 "timezone info가 없다"는 점보다 "어떤 기준 시각을 뜻하는지 팀이 동일하게 이해하는가"가 더 중요합니다.
 배운 점: 시간대 문제는 나중에 운영 로그와 통계에서 더 크게 드러나므로, 기능 구현 단계에서 공통 유틸로 먼저 고정하는 편이 안전합니다.
+
+---
+
+제목 : [chat 처리/LLM 호출 중 DB 커넥션 장기 점유 위험] 프로젝트 - 11
+1. 문제 개요
+오류 상황: `/api/v1/ai/chat` 요청에서 `chat_log` 생성과 retrieval 저장 이후에도 같은 SQLAlchemy 세션을 유지한 채 외부 LLM API를 호출하고 있었습니다.
+발생 배경: 코드 리뷰에서 `db.commit()` 이후에도 세션이 요청 종료 시점까지 살아 있어, 느린 LLM 호출 동안 커넥션 풀이 불필요하게 점유될 수 있다는 피드백이 들어왔습니다.
+2. 오류 코드 및 오류 메시지
+오류 코드: 즉시 드러나는 HTTP 오류는 없었음
+오류 메시지: 별도 메시지 없음
+관련 로그: `app/services/chat_service.py`에서 retrieval 저장 직후 `generate_answer()`, `generate_grouped_answer()`를 호출하는 구조가 확인되었습니다.
+3. 원인 분석
+오류 원인: 요청 단위로 주입된 SQLAlchemy 세션을 끝까지 들고 가는 구조라, DB 작업이 끝난 뒤에도 외부 API 호출 시간만큼 커넥션이 살아 있을 가능성이 있었습니다.
+에러 로그 해석: 런타임 에러보다 구조적 병목 위험에 가까운 이슈였습니다. 트래픽이 증가하면 동시 요청 수만큼 커넥션 풀 고갈 위험이 커집니다.
+구조적 이해: SQLAlchemy 세션은 `commit()` 이후에도 즉시 사라지지 않으며, 일반적으로 요청 종료 또는 명시적 `close()` 시점까지 커넥션 재사용 상태를 유지합니다. 따라서 외부 API 호출처럼 수 초 이상 걸리는 구간과 DB 세션 수명을 분리하는 것이 안전합니다.
+4. 해결책
+단계별 조치 방법:
+Step 1: `chat_log` 생성, 세션 활동 갱신, retrieval 결과 저장까지는 기존 세션에서 처리했습니다.
+Step 2: retrieval 저장 직후 `commit()` 후 `close()`를 호출해 DB 커넥션을 반환했습니다.
+Step 3: LLM 호출은 DB 세션 없이 수행하도록 변경했습니다.
+Step 4: 답변 성공/실패 최종 저장과 `chat_error_log` 적재는 `get_session_factory()`로 새 세션을 열어 마무리하도록 리팩터링했습니다.
+코드 예시:
+```python
+db.commit()
+db.close()
+
+answer_result = generate_answer(question, labeled_chunks)
+
+finalize_db = get_session_factory()()
+try:
+    _finalize_chat_log(finalize_db, ...)
+finally:
+    finalize_db.close()
+```
+추가 자료: https://docs.sqlalchemy.org/en/20/orm/session_basics.html
+5. 교훈 및 주의 사항
+주의할 점: 상태 추적을 위해 중간 커밋이 필요하더라도, 외부 API 호출 구간까지 같은 세션을 유지하지 않도록 주의해야 합니다.
+배운 점: 요청 단위 세션이 편하더라도, 느린 I/O 구간이 끼어드는 서비스에서는 “DB 작업 세션”과 “외부 호출 구간”을 의식적으로 분리해야 처리량 저하를 예방할 수 있습니다.
+
+---
+
+제목 : [regulation 문서 적재/시간 API·COUNT 쿼리·청킹 규칙 하드코딩 문제] 프로젝트 - 12
+1. 문제 개요
+오류 상황: 규정 문서 청킹/적재 코드에서 오래된 시간 API 사용, 비효율적인 count 조회, 빈 본문 청크 형식 불일치, 청크 길이 하드코딩, 긴 문단 미분할 같은 품질 이슈가 함께 존재했습니다.
+발생 배경: PR1 리뷰에서 `regulation_chunk_repository.py`, `regulation_document_service.py`를 중심으로 성능과 유지보수성 관련 피드백이 여러 건 들어왔습니다.
+2. 오류 코드 및 오류 메시지
+오류 코드: 즉시 드러나는 HTTP 오류는 없었음
+오류 메시지: 별도 메시지 없음
+관련 로그: 
+- `datetime.utcnow()` 사용
+- `len(list(...all()))` 형태의 chunk count 계산
+- 본문이 없을 때 `제목:`만 반환하는 분기
+- `800` 글자 제한 하드코딩
+- 긴 단일 문단이 제한 초과여도 그대로 한 청크로 남는 구조
+3. 원인 분석
+오류 원인: 초기 구현 단계에서 “일단 동작하는 구조”를 우선 만들면서, 시간 유틸 통일·DB 집계 최적화·검색용 청크 포맷 일관성·설정 분리 같은 운영성 요소가 뒤로 밀렸습니다.
+에러 로그 해석: 런타임 예외가 아니라, 코드 리뷰를 통해 드러난 잠재 품질 문제였습니다. 트래픽 증가나 문서 다양화가 진행되면 성능/검색 품질 저하로 이어질 가능성이 있었습니다.
+구조적 이해:
+- 시간 API는 Python 버전 변화까지 고려해 미래 호환성을 챙겨야 합니다.
+- 개수 조회는 애플리케이션 메모리로 다 끌고 오지 말고 DB 집계 함수로 처리하는 것이 맞습니다.
+- 검색용 chunk는 본문이 비어 있어도 메타데이터 구조가 일관돼야 retrieval 품질을 예측하기 쉽습니다.
+- 길이 제한과 분할 규칙은 임베딩 모델, 검색 전략 변화에 따라 조정될 수 있으므로 설정화가 필요합니다.
+4. 해결책
+단계별 조치 방법:
+Step 1: `datetime.utcnow()`를 `datetime.now(timezone.utc)`로 교체해 deprecated API 사용을 제거했습니다.
+Step 2: `count_chunks_for_document()`를 `COUNT(*)` 기반 쿼리로 바꿔 불필요한 row 로딩을 없앴습니다.
+Step 3: 본문이 비어 있는 문서도 `_build_chunk_text()`를 타도록 수정해 chunk 형식을 통일했습니다.
+Step 4: `regulation_chunk_max_length`를 설정값으로 분리해 청킹 정책을 코드에서 직접 하드코딩하지 않도록 변경했습니다.
+Step 5: 긴 문단은 공백 기준 우선 분할, 공백이 없으면 최대 길이 기준 강제 분할하도록 보강했습니다.
+코드 예시:
+```python
+ingestion_suffix = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S") + uuid4().hex[:8]
+
+statement = select(func.count()).select_from(RegulationChunk).where(
+    RegulationChunk.regulation_document_id == regulation_document_id
+)
+
+if not content:
+    return [_build_chunk_text(regulation_document, "")]
+```
+추가 자료:
+- https://docs.python.org/3/library/datetime.html
+- https://docs.sqlalchemy.org/en/20/core/functions.html
+5. 교훈 및 주의 사항
+주의할 점: 문서 적재/청킹 코드는 처음엔 단순해 보여도, 검색 품질과 운영 성능에 바로 연결되므로 “작동만 하는 구현”에서 멈추지 않도록 주의해야 합니다.
+배운 점: 리뷰에서 나온 작은 피드백이라도 시간 처리, 집계 쿼리, 청킹 규칙처럼 재사용되는 축이면 바로 문서화해두는 것이 장기적으로 팀 생산성에 도움이 됩니다.
+
+---
+
+제목 : [chat 저장 로직/불필요한 refresh와 실패 시 retrieval 근거 보존 문제] 프로젝트 - 13
+1. 문제 개요
+오류 상황: 채팅 관련 repository에서 `db.flush()` 직후 `db.refresh()`를 반복 호출해 불필요한 SELECT가 발생하고 있었고, 동시에 답변 생성 실패 시에도 검색 근거를 관리자 화면에서 볼 수 있어야 한다는 요구가 함께 제기되었습니다.
+발생 배경: PR 리뷰에서 `chat_retrieval_result` 저장/업데이트 루프와 `touch_chat_session_activity()`에 있는 `refresh()` 호출, 그리고 “LLM 실패 시 retrieval 결과가 롤백으로 사라지지 않는가”에 대한 피드백이 들어왔습니다.
+2. 오류 코드 및 오류 메시지
+오류 코드: 즉시 드러나는 HTTP 오류는 없었음
+오류 메시지: 별도 메시지 없음
+관련 로그:
+- `create_chat_retrieval_results()`에서 row마다 `db.refresh(retrieval_result)` 수행
+- `mark_chat_retrieval_results_used_in_answer()`에서 row마다 `db.refresh(retrieval_result)` 수행
+- `touch_chat_session_activity()`에서 `db.refresh(chat_session)` 수행
+- 채팅 처리 중 LLM 호출 실패 시 검색 근거 row 보존 여부 검토 필요
+3. 원인 분석
+오류 원인: flush 이후 객체 상태를 과도하게 즉시 재조회하는 패턴이 남아 있었고, 실패 경로에서 어떤 데이터까지 “관측 가능해야 하는지”에 대한 정책이 코드 구조에 충분히 드러나지 않았습니다.
+에러 로그 해석: 에러라기보다 성능과 운영 관측성 관점의 구조 개선 포인트였습니다. `refresh()` 루프는 작은 데이터에서는 티가 덜 나지만, row 수가 늘면 N+1 SELECT로 이어질 수 있습니다.
+구조적 이해:
+- SQLAlchemy는 `flush()`만으로도 INSERT된 PK와 세션 내부 변경 상태를 객체에 반영합니다.
+- DB trigger 등으로 DB 쪽에서 값이 바뀌는 경우가 아니라면 직후 `refresh()`가 꼭 필요하지 않습니다.
+- retrieval 결과는 “답변 생성 전 검색 근거”이므로, LLM 실패가 나더라도 관리자 추적을 위해 남겨두는 편이 운영상 유리합니다.
+4. 해결책
+단계별 조치 방법:
+Step 1: `chat_retrieval_result` 생성/업데이트 후 반복 `refresh()`를 제거했습니다.
+Step 2: `touch_chat_session_activity()`의 불필요한 `refresh()`를 제거했습니다.
+Step 3: 채팅 처리 구조를 retrieval 저장까지 먼저 commit하고, 이후 LLM 호출과 최종 상태 저장을 분리해 retrieval 근거가 실패 시에도 보존되도록 유지했습니다.
+코드 예시:
+```python
+db.flush()
+return created_items
+```
+```python
+db.commit()
+db.close()
+
+answer_result = generate_answer(question, labeled_chunks)
+```
+추가 자료:
+- https://docs.sqlalchemy.org/en/20/orm/session_basics.html
+- https://docs.sqlalchemy.org/en/20/orm/session_state_management.html
+5. 교훈 및 주의 사항
+주의할 점: `refresh()`는 “안전해 보이는 기본 동작”처럼 느껴지지만, 실제로는 쿼리 수를 늘리는 비용이 있으므로 필요한 경우에만 써야 합니다.
+배운 점: 운영 추적이 중요한 시스템에서는 “최종 답변 성공 여부”뿐 아니라 “실패 직전까지 확보한 근거 데이터도 남길 것인가”를 의식적으로 설계해야 합니다.

--- a/tests/test_admin_chat_api.py
+++ b/tests/test_admin_chat_api.py
@@ -1,0 +1,175 @@
+from fastapi.testclient import TestClient
+from datetime import datetime
+
+from app.api import admin_chat as admin_chat_module
+from app.core.error_codes import CHAT_LOG_NOT_FOUND
+from app.core.exceptions import AppException
+from app.schemas.admin_chat import AdminChatLogDetail
+from app.schemas.admin_chat import AdminChatSessionSummary
+from app.schemas.admin_chat import AdminRecentChatSessionsResult
+
+
+def test_get_admin_chat_log_api_returns_chat_log_detail(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        admin_chat_module,
+        "get_admin_chat_log_detail",
+        lambda *_args, **_kwargs: AdminChatLogDetail(
+            chat_log_id=11,
+            session_id="session-123",
+            user_id=7,
+            question="외박 신청은 어디서 하나요?",
+            rewritten_query="외박 신청은 어디서 하나요?",
+            answer="포털에서 신청하면 됩니다.",
+            answer_status="SUCCESS",
+            model_name="gpt-4o-mini",
+            prompt_version="chat-answer-v1",
+            retrieval_version="dormitory-search-v1",
+            response_time=321,
+            created_at="2026-04-27T10:00:00",
+            retrieval_results=[
+                {
+                    "chat_retrieval_result_id": 21,
+                    "regulation_chunk_id": 1001,
+                    "document_id": "dorm-rule",
+                    "document_version": "v1",
+                    "chunk_id": "chunk-1",
+                    "retrieval_rank": 1,
+                    "retrieval_score": 0.98,
+                    "rerank_score": None,
+                    "retrieval_method": "vector_dormitory_top_k",
+                    "used_in_answer": True,
+                    "selected_as_citation": False,
+                    "citation_order": None,
+                    "created_at": datetime(2026, 4, 27, 10, 0, 1),
+                }
+            ],
+        ),
+    )
+
+    response = client.get(
+        "/api/v1/admin/chat/logs/11",
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": 200,
+        "message": "chat log retrieved",
+        "data": {
+            "chat_log_id": 11,
+            "session_id": "session-123",
+            "user_id": 7,
+            "question": "외박 신청은 어디서 하나요?",
+            "rewritten_query": "외박 신청은 어디서 하나요?",
+            "answer": "포털에서 신청하면 됩니다.",
+            "answer_status": "SUCCESS",
+            "model_name": "gpt-4o-mini",
+            "prompt_version": "chat-answer-v1",
+            "retrieval_version": "dormitory-search-v1",
+            "response_time": 321,
+            "created_at": "2026-04-27T10:00:00",
+            "retrieval_results": [
+                {
+                    "chat_retrieval_result_id": 21,
+                    "regulation_chunk_id": 1001,
+                    "document_id": "dorm-rule",
+                    "document_version": "v1",
+                    "chunk_id": "chunk-1",
+                    "retrieval_rank": 1,
+                    "retrieval_score": 0.98,
+                    "rerank_score": None,
+                    "retrieval_method": "vector_dormitory_top_k",
+                    "used_in_answer": True,
+                    "selected_as_citation": False,
+                    "citation_order": None,
+                    "created_at": "2026-04-27T10:00:01",
+                }
+            ],
+        },
+        "error_code": None,
+    }
+
+
+def test_get_admin_chat_log_api_returns_not_found_error(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        admin_chat_module,
+        "get_admin_chat_log_detail",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AppException(CHAT_LOG_NOT_FOUND)),
+    )
+
+    response = client.get(
+        "/api/v1/admin/chat/logs/999",
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "status": 404,
+        "message": "chat log not found",
+        "data": None,
+        "error_code": "CHAT_LOG_NOT_FOUND",
+    }
+
+
+def test_get_recent_admin_chat_sessions_api_returns_latest_10(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        admin_chat_module,
+        "get_recent_admin_chat_sessions",
+        lambda *_args, **_kwargs: AdminRecentChatSessionsResult(
+            items=[
+                AdminChatSessionSummary(
+                    session_id="session-123",
+                    user_id=7,
+                    total_turns=3,
+                    started_at="2026-04-27T09:30:00",
+                    last_activity_at="2026-04-27T10:00:00",
+                ),
+                AdminChatSessionSummary(
+                    session_id="session-456",
+                    user_id=None,
+                    total_turns=1,
+                    started_at="2026-04-27T09:00:00",
+                    last_activity_at="2026-04-27T09:10:00",
+                ),
+            ]
+        ),
+    )
+
+    response = client.get(
+        "/api/v1/admin/chat/sessions/recent",
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": 200,
+        "message": "recent chat sessions retrieved",
+        "data": {
+            "items": [
+                {
+                    "session_id": "session-123",
+                    "user_id": 7,
+                    "total_turns": 3,
+                    "started_at": "2026-04-27T09:30:00",
+                    "last_activity_at": "2026-04-27T10:00:00",
+                },
+                {
+                    "session_id": "session-456",
+                    "user_id": None,
+                    "total_turns": 1,
+                    "started_at": "2026-04-27T09:00:00",
+                    "last_activity_at": "2026-04-27T09:10:00",
+                },
+            ]
+        },
+        "error_code": None,
+    }

--- a/tests/test_admin_chat_api.py
+++ b/tests/test_admin_chat_api.py
@@ -46,6 +46,16 @@ def test_get_admin_chat_log_api_returns_chat_log_detail(
                     "created_at": datetime(2026, 4, 27, 10, 0, 1),
                 }
             ],
+            error_logs=[
+                {
+                    "error_id": 31,
+                    "error_type": "LLM_API_ERROR",
+                    "error_message": "llm failed",
+                    "error_detail": "RuntimeError: llm failed",
+                    "occurred_step": "ANSWER_GENERATION",
+                    "created_at": datetime(2026, 4, 27, 10, 0, 2),
+                }
+            ],
         ),
     )
 
@@ -86,6 +96,16 @@ def test_get_admin_chat_log_api_returns_chat_log_detail(
                     "selected_as_citation": False,
                     "citation_order": None,
                     "created_at": "2026-04-27T10:00:01",
+                }
+            ],
+            "error_logs": [
+                {
+                    "error_id": 31,
+                    "error_type": "LLM_API_ERROR",
+                    "error_message": "llm failed",
+                    "error_detail": "RuntimeError: llm failed",
+                    "occurred_step": "ANSWER_GENERATION",
+                    "created_at": "2026-04-27T10:00:02",
                 }
             ],
         },

--- a/tests/test_admin_chat_api.py
+++ b/tests/test_admin_chat_api.py
@@ -132,6 +132,7 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     total_turns=3,
                     started_at="2026-04-27T09:30:00",
                     last_activity_at="2026-04-27T10:00:00",
+                    is_expired=False,
                 ),
                 AdminChatSessionSummary(
                     session_id="session-456",
@@ -139,6 +140,7 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     total_turns=1,
                     started_at="2026-04-27T09:00:00",
                     last_activity_at="2026-04-27T09:10:00",
+                    is_expired=True,
                 ),
             ]
         ),
@@ -161,6 +163,7 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     "total_turns": 3,
                     "started_at": "2026-04-27T09:30:00",
                     "last_activity_at": "2026-04-27T10:00:00",
+                    "is_expired": False,
                 },
                 {
                     "session_id": "session-456",
@@ -168,6 +171,7 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     "total_turns": 1,
                     "started_at": "2026-04-27T09:00:00",
                     "last_activity_at": "2026-04-27T09:10:00",
+                    "is_expired": True,
                 },
             ]
         },

--- a/tests/test_admin_chat_service.py
+++ b/tests/test_admin_chat_service.py
@@ -51,6 +51,24 @@ def test_get_admin_chat_log_detail_returns_mapped_schema(monkeypatch: pytest.Mon
             )()
         ],
     )
+    monkeypatch.setattr(
+        admin_chat_service,
+        "list_chat_error_logs_by_chat_log_id",
+        lambda *_args, **_kwargs: [
+            type(
+                "ChatErrorLogStub",
+                (),
+                {
+                    "error_id": 31,
+                    "error_type": "LLM_API_ERROR",
+                    "error_message": "llm failed",
+                    "error_detail": "RuntimeError: llm failed",
+                    "occurred_step": "ANSWER_GENERATION",
+                    "created_at": datetime(2026, 4, 27, 10, 0, 2),
+                },
+            )()
+        ],
+    )
 
     result = admin_chat_service.get_admin_chat_log_detail(object(), 11)
 
@@ -59,6 +77,8 @@ def test_get_admin_chat_log_detail_returns_mapped_schema(monkeypatch: pytest.Mon
     assert result.answer_status == "SUCCESS"
     assert len(result.retrieval_results) == 1
     assert result.retrieval_results[0].regulation_chunk_id == 1001
+    assert len(result.error_logs) == 1
+    assert result.error_logs[0].error_type == "LLM_API_ERROR"
 
 
 def test_get_admin_chat_log_detail_raises_not_found(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_admin_chat_service.py
+++ b/tests/test_admin_chat_service.py
@@ -96,9 +96,13 @@ def test_get_recent_admin_chat_sessions_returns_up_to_10(monkeypatch: pytest.Mon
         )(),
     ]
     monkeypatch.setattr(admin_chat_service, "list_recent_chat_sessions", lambda *_args, **_kwargs: sessions)
+    monkeypatch.setattr(admin_chat_service, "get_settings", lambda: type("SettingsStub", (), {"chat_session_timeout_minutes": 30})())
+    monkeypatch.setattr(admin_chat_service, "get_current_utc_time", lambda: datetime(2026, 4, 27, 10, 0, 1))
 
     result = admin_chat_service.get_recent_admin_chat_sessions(object())
 
     assert len(result.items) == 2
     assert result.items[0].session_id == "session-123"
     assert result.items[1].session_id == "session-456"
+    assert result.items[0].is_expired is False
+    assert result.items[1].is_expired is True

--- a/tests/test_admin_chat_service.py
+++ b/tests/test_admin_chat_service.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+import pytest
+
+from app.core.exceptions import AppException
+from app.services import admin_chat_service
+
+
+def test_get_admin_chat_log_detail_returns_mapped_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    chat_log = type(
+        "ChatLogStub",
+        (),
+        {
+            "chat_log_id": 11,
+            "session_id": "session-123",
+            "user_id": 7,
+            "question": "외박 신청은 어디서 하나요?",
+            "rewritten_query": "외박 신청은 어디서 하나요?",
+            "answer": "포털에서 신청하면 됩니다.",
+            "answer_status": type("StatusStub", (), {"value": "SUCCESS"})(),
+            "model_name": "gpt-4o-mini",
+            "prompt_version": "chat-answer-v1",
+            "retrieval_version": "dormitory-search-v1",
+            "response_time": 123,
+            "created_at": datetime(2026, 4, 27, 10, 0, 0),
+        },
+    )()
+    monkeypatch.setattr(admin_chat_service, "get_chat_log_by_id", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(
+        admin_chat_service,
+        "list_chat_retrieval_results_by_chat_log_id",
+        lambda *_args, **_kwargs: [
+            type(
+                "ChatRetrievalResultStub",
+                (),
+                {
+                    "chat_retrieval_result_id": 21,
+                    "regulation_chunk_id": 1001,
+                    "document_id": "dorm-rule",
+                    "document_version": "v1",
+                    "chunk_id": "chunk-1",
+                    "retrieval_rank": 1,
+                    "retrieval_score": 0.98,
+                    "rerank_score": None,
+                    "retrieval_method": "vector_dormitory_top_k",
+                    "used_in_answer": True,
+                    "selected_as_citation": False,
+                    "citation_order": None,
+                    "created_at": datetime(2026, 4, 27, 10, 0, 1),
+                },
+            )()
+        ],
+    )
+
+    result = admin_chat_service.get_admin_chat_log_detail(object(), 11)
+
+    assert result.chat_log_id == 11
+    assert result.session_id == "session-123"
+    assert result.answer_status == "SUCCESS"
+    assert len(result.retrieval_results) == 1
+    assert result.retrieval_results[0].regulation_chunk_id == 1001
+
+
+def test_get_admin_chat_log_detail_raises_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin_chat_service, "get_chat_log_by_id", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AppException) as exc_info:
+        admin_chat_service.get_admin_chat_log_detail(object(), 999)
+
+    assert exc_info.value.error_code.code == "CHAT_LOG_NOT_FOUND"
+
+
+def test_get_recent_admin_chat_sessions_returns_up_to_10(monkeypatch: pytest.MonkeyPatch) -> None:
+    sessions = [
+        type(
+            "ChatSessionStub",
+            (),
+            {
+                "session_id": "session-123",
+                "user_id": 7,
+                "total_turns": 3,
+                "started_at": datetime(2026, 4, 27, 9, 30, 0),
+                "last_activity_at": datetime(2026, 4, 27, 10, 0, 0),
+            },
+        )(),
+        type(
+            "ChatSessionStub",
+            (),
+            {
+                "session_id": "session-456",
+                "user_id": None,
+                "total_turns": 1,
+                "started_at": datetime(2026, 4, 27, 9, 0, 0),
+                "last_activity_at": datetime(2026, 4, 27, 9, 10, 0),
+            },
+        )(),
+    ]
+    monkeypatch.setattr(admin_chat_service, "list_recent_chat_sessions", lambda *_args, **_kwargs: sessions)
+
+    result = admin_chat_service.get_recent_admin_chat_sessions(object())
+
+    assert len(result.items) == 2
+    assert result.items[0].session_id == "session-123"
+    assert result.items[1].session_id == "session-456"

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+from app.api import chat as chat_module
+from app.core.error_codes import CHAT_SESSION_EXPIRED
+from app.core.exceptions import AppException
+from app.schemas.chat import ChatResponse
+
+
+def test_chat_api_returns_service_response(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_module,
+        "answer_chat_question",
+        lambda *_args, **_kwargs: ChatResponse(
+            chat_log_id=101,
+            session_id="session-123",
+            answer="생활관 규정에 따라 가능합니다.",
+            answer_status="SUCCESS",
+            source_url="https://example.com/rules/1",
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/ai/chat",
+        json={
+            "session_id": "session-123",
+            "question": "외박 신청은 어디서 하나요?",
+            "dormitory": "제1학생생활관",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "chat_log_id": 101,
+        "session_id": "session-123",
+        "answer": "생활관 규정에 따라 가능합니다.",
+        "answer_status": "SUCCESS",
+        "source_url": "https://example.com/rules/1",
+    }
+
+
+def test_chat_api_returns_common_error_response_for_expired_session(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_module,
+        "answer_chat_question",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AppException(
+                CHAT_SESSION_EXPIRED,
+                detail="chat session expired after 30 minutes of inactivity. please start a new chat session",
+            )
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/ai/chat",
+        json={
+            "session_id": "session-123",
+            "question": "외박 신청은 어디서 하나요?",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "status": 409,
+        "message": "chat session expired after 30 minutes of inactivity. please start a new chat session",
+        "data": None,
+        "error_code": "CHAT_SESSION_EXPIRED",
+    }

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -1,0 +1,275 @@
+from datetime import datetime
+
+import pytest
+
+from app.core.exceptions import AppException
+from app.db.models.chat_enums import ChatAnswerStatus
+from app.schemas.chat import ChatRequest
+from app.services import chat_service
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.commit_count = 0
+        self.flush_count = 0
+        self.rollback_count = 0
+        self.refreshed_objects: list[object] = []
+
+    def commit(self) -> None:
+        self.commit_count += 1
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+    def rollback(self) -> None:
+        self.rollback_count += 1
+
+    def refresh(self, value) -> None:
+        self.refreshed_objects.append(value)
+
+
+def _build_chat_session():
+    return type(
+        "ChatSessionStub",
+        (),
+        {
+            "session_id": "session-123",
+            "user_id": 7,
+            "total_turns": 0,
+            "last_activity_at": datetime(2026, 4, 27, 10, 0, 0),
+        },
+    )()
+
+
+def _build_chat_log():
+    return type(
+        "ChatLogStub",
+        (),
+        {
+            "chat_log_id": 501,
+            "session_id": "session-123",
+            "question": "외박 신청은 어디서 하나요?",
+            "answer_status": ChatAnswerStatus.PROCESSING,
+            "answer": None,
+            "rewritten_query": None,
+            "model_name": None,
+            "prompt_version": None,
+            "retrieval_version": None,
+            "response_time": None,
+        },
+    )()
+
+
+def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeSession()
+    chat_session = _build_chat_session()
+    chat_log = _build_chat_log()
+
+    retrieval_calls: dict[str, object] = {}
+
+    monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (True, "외박 신청은 어디서 하나요?"))
+    monkeypatch.setattr(chat_service, "create_query_embedding", lambda *_args, **_kwargs: [0.1, 0.2, 0.3])
+    monkeypatch.setattr(
+        chat_service,
+        "search_similar_chunks",
+        lambda *_args, **_kwargs: [
+            {
+                "regulation_chunk_id": 1001,
+                "document_id": "dorm-rule",
+                "document_version": "v1",
+                "chunk_id": "chunk-1",
+                "content": "외박 신청은 포털에서 가능합니다.",
+                "source_url": "https://example.com/rules/1",
+                "similarity": 0.98,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "generate_answer",
+        lambda *_args, **_kwargs: ("포털에서 외박 신청을 하면 됩니다.", "https://example.com/rules/1"),
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "create_chat_retrieval_results",
+        lambda *_args, **kwargs: retrieval_calls.update(kwargs) or [],
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "mark_chat_retrieval_results_used_in_answer",
+        lambda *_args, **kwargs: retrieval_calls.update({"mark_used_chat_log_id": kwargs["chat_log_id"]}) or [],
+    )
+
+    response = chat_service.answer_chat_question(
+        db,
+        ChatRequest(
+            session_id="session-123",
+            question="외박 신청은 어디서 하나요?",
+            dormitory="제1학생생활관",
+        ),
+    )
+
+    assert response.chat_log_id == 501
+    assert response.session_id == "session-123"
+    assert response.answer == "포털에서 외박 신청을 하면 됩니다."
+    assert response.answer_status == "SUCCESS"
+    assert response.source_url == "https://example.com/rules/1"
+    assert chat_log.answer_status == ChatAnswerStatus.SUCCESS
+    assert chat_log.rewritten_query == "외박 신청은 어디서 하나요?"
+    assert chat_log.model_name == chat_service.ANSWER_MODEL_NAME
+    assert chat_log.prompt_version == chat_service.PROMPT_VERSION_SINGLE
+    assert chat_log.retrieval_version == chat_service.RETRIEVAL_VERSION_SINGLE
+    assert retrieval_calls["chat_log_id"] == 501
+    assert retrieval_calls["retrieval_method"] == chat_service.RETRIEVAL_METHOD_SINGLE
+    assert retrieval_calls["retrieval_items"][0]["regulation_chunk_id"] == 1001
+    assert retrieval_calls["mark_used_chat_log_id"] == 501
+    assert db.commit_count == 2
+    assert db.flush_count == 1
+    assert db.rollback_count == 0
+
+
+def test_answer_chat_question_returns_no_answer_for_invalid_question(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeSession()
+    chat_session = _build_chat_session()
+    chat_log = _build_chat_log()
+
+    monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (False, "질문이 너무 짧습니다."))
+    monkeypatch.setattr(
+        chat_service,
+        "create_chat_retrieval_results",
+        lambda *_args, **_kwargs: pytest.fail("invalid question should not save retrieval results"),
+    )
+
+    response = chat_service.answer_chat_question(
+        db,
+        ChatRequest(
+            session_id="session-123",
+            question="?",
+        ),
+    )
+
+    assert response.answer == chat_service.INVALID_QUESTION_MESSAGE
+    assert response.answer_status == "NO_ANSWER"
+    assert response.source_url == ""
+    assert chat_log.answer_status == ChatAnswerStatus.NO_ANSWER
+    assert chat_log.rewritten_query == "질문이 너무 짧습니다."
+    assert db.commit_count == 2
+    assert db.flush_count == 1
+    assert db.rollback_count == 0
+
+
+def test_answer_chat_question_raises_not_found_when_session_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeSession()
+    monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AppException) as exc_info:
+        chat_service.answer_chat_question(
+            db,
+            ChatRequest(
+                session_id="missing-session",
+                question="외박 신청은 어디서 하나요?",
+            ),
+        )
+
+    assert exc_info.value.error_code.code == "CHAT_SESSION_NOT_FOUND"
+    assert db.commit_count == 0
+
+
+def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeSession()
+    chat_session = _build_chat_session()
+    chat_log = _build_chat_log()
+
+    retrieval_calls: dict[str, object] = {}
+
+    monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (True, "외박 신청은 어디서 하나요?"))
+    monkeypatch.setattr(chat_service, "create_query_embedding", lambda *_args, **_kwargs: [0.1, 0.2, 0.3])
+    monkeypatch.setattr(
+        chat_service,
+        "search_similar_chunks",
+        lambda *_args, **_kwargs: [
+            {
+                "regulation_chunk_id": 1001,
+                "document_id": "dorm-rule",
+                "document_version": "v1",
+                "chunk_id": "chunk-1",
+                "content": "외박 신청은 포털에서 가능합니다.",
+                "source_url": "https://example.com/rules/1",
+                "similarity": 0.98,
+            }
+        ],
+    )
+
+    def raise_generation_error(*_args, **_kwargs):
+        raise RuntimeError("llm failed")
+
+    monkeypatch.setattr(chat_service, "generate_answer", raise_generation_error)
+    monkeypatch.setattr(
+        chat_service,
+        "create_chat_retrieval_results",
+        lambda *_args, **kwargs: retrieval_calls.update(kwargs) or [],
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "mark_chat_retrieval_results_used_in_answer",
+        lambda *_args, **_kwargs: pytest.fail("failed generation should not mark retrieval results used"),
+    )
+
+    with pytest.raises(RuntimeError, match="llm failed"):
+        chat_service.answer_chat_question(
+            db,
+            ChatRequest(
+                session_id="session-123",
+                question="외박 신청은 어디서 하나요?",
+                dormitory="제1학생생활관",
+            ),
+        )
+
+    assert chat_log.answer_status == ChatAnswerStatus.ERROR
+    assert chat_log.rewritten_query == "외박 신청은 어디서 하나요?"
+    assert chat_log.answer == ""
+    assert retrieval_calls["chat_log_id"] == 501
+    assert db.commit_count == 2
+    assert db.flush_count == 1
+    assert db.rollback_count == 1
+
+
+def test_answer_chat_question_raises_expired_when_session_is_inactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = FakeSession()
+    expired_chat_session = _build_chat_session()
+    expired_chat_session.last_activity_at = datetime(2026, 4, 27, 9, 0, 0)
+
+    monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: expired_chat_session)
+    monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: pytest.fail("chat_log should not be created"))
+    monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: pytest.fail("expired session should not be updated"))
+    monkeypatch.setattr(chat_service, "get_settings", lambda: type("SettingsStub", (), {"chat_session_timeout_minutes": 30})())
+
+    class FrozenDateTime:
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime(2026, 4, 27, 10, 0, 1)
+
+    monkeypatch.setattr(chat_service, "datetime", FrozenDateTime)
+
+    with pytest.raises(AppException) as exc_info:
+        chat_service.answer_chat_question(
+            db,
+            ChatRequest(
+                session_id="session-123",
+                question="외박 신청은 어디서 하나요?",
+            ),
+        )
+
+    assert exc_info.value.error_code.code == "CHAT_SESSION_EXPIRED"
+    assert "30 minutes" in exc_info.value.detail
+    assert db.commit_count == 0
+    assert db.flush_count == 0

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -14,6 +14,7 @@ class FakeSession:
         self.commit_count = 0
         self.flush_count = 0
         self.rollback_count = 0
+        self.close_count = 0
         self.refreshed_objects: list[object] = []
 
     def commit(self) -> None:
@@ -27,6 +28,9 @@ class FakeSession:
 
     def refresh(self, value) -> None:
         self.refreshed_objects.append(value)
+
+    def close(self) -> None:
+        self.close_count += 1
 
 
 def _build_chat_session():
@@ -63,6 +67,7 @@ def _build_chat_log():
 
 def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: pytest.MonkeyPatch) -> None:
     db = FakeSession()
+    finalize_db = FakeSession()
     chat_session = _build_chat_session()
     chat_log = _build_chat_log()
 
@@ -70,7 +75,9 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
 
     monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
     monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "get_chat_log_by_id", lambda *_args, **_kwargs: chat_log)
     monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "get_session_factory", lambda: (lambda: finalize_db))
     monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (True, "외박 신청은 어디서 하나요?"))
     monkeypatch.setattr(chat_service, "create_query_embedding", lambda *_args, **_kwargs: [0.1, 0.2, 0.3])
     monkeypatch.setattr(
@@ -140,7 +147,10 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
     assert retrieval_calls["mark_used_chat_log_id"] == 501
     assert retrieval_calls["cited_regulation_chunk_ids"] == [1001]
     assert db.commit_count == 2
-    assert db.flush_count == 1
+    assert db.close_count == 1
+    assert finalize_db.commit_count == 1
+    assert db.flush_count == 0
+    assert finalize_db.flush_count == 1
     assert db.rollback_count == 0
 
 
@@ -151,6 +161,7 @@ def test_answer_chat_question_returns_no_answer_for_invalid_question(monkeypatch
 
     monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
     monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "get_chat_log_by_id", lambda *_args, **_kwargs: chat_log)
     monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
     monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (False, "질문이 너무 짧습니다."))
     monkeypatch.setattr(
@@ -173,6 +184,7 @@ def test_answer_chat_question_returns_no_answer_for_invalid_question(monkeypatch
     assert chat_log.answer_status == ChatAnswerStatus.NO_ANSWER
     assert chat_log.rewritten_query == "질문이 너무 짧습니다."
     assert db.commit_count == 2
+    assert db.close_count == 0
     assert db.flush_count == 1
     assert db.rollback_count == 0
 
@@ -196,6 +208,7 @@ def test_answer_chat_question_raises_not_found_when_session_missing(monkeypatch:
 
 def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     db = FakeSession()
+    finalize_db = FakeSession()
     chat_session = _build_chat_session()
     chat_log = _build_chat_log()
 
@@ -204,7 +217,9 @@ def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pyt
 
     monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
     monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
+    monkeypatch.setattr(chat_service, "get_chat_log_by_id", lambda *_args, **_kwargs: chat_log)
     monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: chat_session)
+    monkeypatch.setattr(chat_service, "get_session_factory", lambda: (lambda: finalize_db))
     monkeypatch.setattr(chat_service, "validate_question", lambda *_args, **_kwargs: (True, "외박 신청은 어디서 하나요?"))
     monkeypatch.setattr(chat_service, "create_query_embedding", lambda *_args, **_kwargs: [0.1, 0.2, 0.3])
     monkeypatch.setattr(
@@ -264,7 +279,10 @@ def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pyt
     assert error_log_calls["error_message"] == "llm failed"
     assert error_log_calls["error_detail"] == "RuntimeError: llm failed"
     assert db.commit_count == 2
-    assert db.flush_count == 1
+    assert db.close_count == 1
+    assert finalize_db.commit_count == 1
+    assert db.flush_count == 0
+    assert finalize_db.flush_count == 1
     assert db.rollback_count == 1
 
 

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -6,6 +6,7 @@ from app.core.exceptions import AppException
 from app.db.models.chat_enums import ChatAnswerStatus
 from app.schemas.chat import ChatRequest
 from app.services import chat_service
+from app.services.generator import AnswerGenerationResult
 
 
 class FakeSession:
@@ -90,7 +91,11 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
     monkeypatch.setattr(
         chat_service,
         "generate_answer",
-        lambda *_args, **_kwargs: ("포털에서 외박 신청을 하면 됩니다.", "https://example.com/rules/1"),
+        lambda *_args, **_kwargs: AnswerGenerationResult(
+            answer="포털에서 외박 신청을 하면 됩니다. [C1]",
+            source_url="https://example.com/rules/1",
+            cited_regulation_chunk_ids=[1001],
+        ),
     )
     monkeypatch.setattr(
         chat_service,
@@ -100,7 +105,13 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
     monkeypatch.setattr(
         chat_service,
         "mark_chat_retrieval_results_used_in_answer",
-        lambda *_args, **kwargs: retrieval_calls.update({"mark_used_chat_log_id": kwargs["chat_log_id"]}) or [],
+        lambda *_args, **kwargs: retrieval_calls.update(
+            {
+                "mark_used_chat_log_id": kwargs["chat_log_id"],
+                "cited_regulation_chunk_ids": kwargs["cited_regulation_chunk_ids"],
+            }
+        )
+        or [],
     )
 
     response = chat_service.answer_chat_question(
@@ -114,7 +125,7 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
 
     assert response.chat_log_id == 501
     assert response.session_id == "session-123"
-    assert response.answer == "포털에서 외박 신청을 하면 됩니다."
+    assert response.answer == "포털에서 외박 신청을 하면 됩니다. [C1]"
     assert response.answer_status == "SUCCESS"
     assert response.source_url == "https://example.com/rules/1"
     assert chat_log.answer_status == ChatAnswerStatus.SUCCESS
@@ -125,7 +136,9 @@ def test_answer_chat_question_returns_success_for_single_dormitory(monkeypatch: 
     assert retrieval_calls["chat_log_id"] == 501
     assert retrieval_calls["retrieval_method"] == chat_service.RETRIEVAL_METHOD_SINGLE
     assert retrieval_calls["retrieval_items"][0]["regulation_chunk_id"] == 1001
+    assert retrieval_calls["retrieval_items"][0]["citation_label"] == "C1"
     assert retrieval_calls["mark_used_chat_log_id"] == 501
+    assert retrieval_calls["cited_regulation_chunk_ids"] == [1001]
     assert db.commit_count == 2
     assert db.flush_count == 1
     assert db.rollback_count == 0
@@ -187,6 +200,7 @@ def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pyt
     chat_log = _build_chat_log()
 
     retrieval_calls: dict[str, object] = {}
+    error_log_calls: dict[str, object] = {}
 
     monkeypatch.setattr(chat_service, "get_chat_session", lambda *_args, **_kwargs: chat_session)
     monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: chat_log)
@@ -223,6 +237,11 @@ def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pyt
         "mark_chat_retrieval_results_used_in_answer",
         lambda *_args, **_kwargs: pytest.fail("failed generation should not mark retrieval results used"),
     )
+    monkeypatch.setattr(
+        chat_service,
+        "create_chat_error_log",
+        lambda *_args, **kwargs: error_log_calls.update(kwargs) or object(),
+    )
 
     with pytest.raises(RuntimeError, match="llm failed"):
         chat_service.answer_chat_question(
@@ -238,6 +257,12 @@ def test_answer_chat_question_marks_error_when_generation_fails(monkeypatch: pyt
     assert chat_log.rewritten_query == "외박 신청은 어디서 하나요?"
     assert chat_log.answer == ""
     assert retrieval_calls["chat_log_id"] == 501
+    assert error_log_calls["chat_log_id"] == 501
+    assert error_log_calls["session_id"] == "session-123"
+    assert error_log_calls["error_type"] == chat_service.ERROR_TYPE_LLM_API
+    assert error_log_calls["occurred_step"] == chat_service.STEP_ANSWER_GENERATION
+    assert error_log_calls["error_message"] == "llm failed"
+    assert error_log_calls["error_detail"] == "RuntimeError: llm failed"
     assert db.commit_count == 2
     assert db.flush_count == 1
     assert db.rollback_count == 1
@@ -310,3 +335,23 @@ def test_flatten_grouped_retrieval_items_deduplicates_same_chunk() -> None:
     assert len(result) == 2
     assert result[0]["regulation_chunk_id"] == 16
     assert result[1]["regulation_chunk_id"] == 13
+
+
+def test_assign_citation_labels_adds_sequential_labels() -> None:
+    result = chat_service._assign_citation_labels(
+        [
+            {"regulation_chunk_id": 16, "chunk_id": "chunk-a"},
+            {"regulation_chunk_id": 13, "chunk_id": "chunk-b"},
+        ]
+    )
+
+    assert result[0]["citation_label"] == "C1"
+    assert result[1]["citation_label"] == "C2"
+
+
+def test_build_chat_error_metadata_defaults_timeout_error() -> None:
+    result = chat_service._build_chat_error_metadata(TimeoutError("request timed out"))
+
+    assert result.error_type == chat_service.ERROR_TYPE_TIMEOUT
+    assert result.occurred_step is None
+    assert result.error_message == "request timed out"

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -252,13 +252,7 @@ def test_answer_chat_question_raises_expired_when_session_is_inactive(monkeypatc
     monkeypatch.setattr(chat_service, "create_chat_log", lambda *_args, **_kwargs: pytest.fail("chat_log should not be created"))
     monkeypatch.setattr(chat_service, "touch_chat_session_activity", lambda *_args, **_kwargs: pytest.fail("expired session should not be updated"))
     monkeypatch.setattr(chat_service, "get_settings", lambda: type("SettingsStub", (), {"chat_session_timeout_minutes": 30})())
-
-    class FrozenDateTime:
-        @staticmethod
-        def utcnow() -> datetime:
-            return datetime(2026, 4, 27, 10, 0, 1)
-
-    monkeypatch.setattr(chat_service, "datetime", FrozenDateTime)
+    monkeypatch.setattr(chat_service, "get_current_utc_time", lambda: datetime(2026, 4, 27, 10, 0, 1))
 
     with pytest.raises(AppException) as exc_info:
         chat_service.answer_chat_question(
@@ -273,3 +267,46 @@ def test_answer_chat_question_raises_expired_when_session_is_inactive(monkeypatc
     assert "30 minutes" in exc_info.value.detail
     assert db.commit_count == 0
     assert db.flush_count == 0
+
+
+def test_flatten_grouped_retrieval_items_deduplicates_same_chunk() -> None:
+    dormitory_chunks = {
+        "제1학생생활관": [
+            {
+                "regulation_chunk_id": 16,
+                "document_id": "admission_008",
+                "document_version": "v1",
+                "chunk_id": "chunk-a",
+                "similarity": 0.429,
+            },
+            {
+                "regulation_chunk_id": 13,
+                "document_id": "admission_005",
+                "document_version": "v1",
+                "chunk_id": "chunk-b",
+                "similarity": 0.416,
+            },
+        ],
+        "제2학생생활관": [
+            {
+                "regulation_chunk_id": 16,
+                "document_id": "admission_008",
+                "document_version": "v1",
+                "chunk_id": "chunk-a",
+                "similarity": 0.429,
+            },
+            {
+                "regulation_chunk_id": 13,
+                "document_id": "admission_005",
+                "document_version": "v1",
+                "chunk_id": "chunk-b",
+                "similarity": 0.416,
+            },
+        ],
+    }
+
+    result = chat_service._flatten_grouped_retrieval_items(dormitory_chunks)
+
+    assert len(result) == 2
+    assert result[0]["regulation_chunk_id"] == 16
+    assert result[1]["regulation_chunk_id"] == 13

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,26 @@
+from app.services import generator
+
+
+def test_extract_cited_regulation_chunk_ids_returns_unique_ids_in_order() -> None:
+    chunks = [
+        {"citation_label": "C1", "regulation_chunk_id": 16, "source_url": "https://example.com/1"},
+        {"citation_label": "C2", "regulation_chunk_id": 13, "source_url": "https://example.com/2"},
+    ]
+
+    result = generator._extract_cited_regulation_chunk_ids(
+        "외박 신청은 포털에서 하면 됩니다. [C2] 추가 확인은 규정을 보세요. [C1] 다시 참고 [C2]",
+        chunks,
+    )
+
+    assert result == [13, 16]
+
+
+def test_resolve_source_url_prefers_first_cited_chunk() -> None:
+    chunks = [
+        {"citation_label": "C1", "regulation_chunk_id": 16, "source_url": "https://example.com/1"},
+        {"citation_label": "C2", "regulation_chunk_id": 13, "source_url": "https://example.com/2"},
+    ]
+
+    result = generator._resolve_source_url(chunks, [13])
+
+    assert result == "https://example.com/2"

--- a/tests/test_regulation_chunk_repository.py
+++ b/tests/test_regulation_chunk_repository.py
@@ -51,3 +51,17 @@ def test_create_regulation_chunks_for_document_maps_document_fields_to_model() -
     assert regulation_chunk.embedding_model == "text-embedding-3-small"
     assert db.flush_called is True
     assert db.refresh_called_values == [regulation_chunk]
+
+
+def test_count_chunks_for_document_uses_count_query() -> None:
+    executed_statements: list[object] = []
+
+    class CountSession:
+        def execute(self, statement):
+            executed_statements.append(statement)
+            return SimpleNamespace(scalar=lambda: 3)
+
+    result = regulation_chunk_repository.count_chunks_for_document(CountSession(), 7)
+
+    assert result == 3
+    assert len(executed_statements) == 1

--- a/tests/test_regulation_document_service.py
+++ b/tests/test_regulation_document_service.py
@@ -104,6 +104,65 @@ def test_create_regulation_document_with_ingestion_returns_success(monkeypatch: 
     assert result.triggered_action == "document_created"
 
 
+def test_chunk_document_content_returns_standard_chunk_when_content_is_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        regulation_document_service,
+        "get_settings",
+        lambda: type("SettingsStub", (), {"regulation_chunk_max_length": 800})(),
+    )
+    regulation_document = type(
+        "RegulationDocumentStub",
+        (),
+        {
+            "content": "",
+            "title": "외박 신청",
+            "dormitory": "제1학생생활관",
+            "category": "입퇴사 안내",
+            "keywords": ["외박"],
+            "source": "생활관 안내",
+            "source_url": "https://example.com/rules",
+            "source_type": "official",
+        },
+    )()
+
+    chunks = regulation_document_service._chunk_document_content(regulation_document)
+
+    assert len(chunks) == 1
+    assert "제목: 외박 신청" in chunks[0]
+    assert "본문:" in chunks[0]
+
+
+def test_chunk_document_content_splits_long_paragraphs_by_max_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        regulation_document_service,
+        "get_settings",
+        lambda: type("SettingsStub", (), {"regulation_chunk_max_length": 20})(),
+    )
+    regulation_document = type(
+        "RegulationDocumentStub",
+        (),
+        {
+            "content": "가나다라마바사아자차카타파하 가나다라마바사아자차카타파하",
+            "title": "긴 문단 테스트",
+            "dormitory": None,
+            "category": None,
+            "keywords": None,
+            "source": None,
+            "source_url": None,
+            "source_type": None,
+        },
+    )()
+
+    chunks = regulation_document_service._chunk_document_content(regulation_document)
+
+    assert len(chunks) >= 2
+    assert all("본문:" in chunk for chunk in chunks)
+
+
 def test_create_regulation_documents_with_ingestion_returns_partial_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION

## 유형

- [x] Feat
- [ ] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

챗봇 세션 시작부터 질문 처리, 검색 결과 저장, 답변 인용 추적, 오류 로그 적재까지 채팅 코어 흐름을 정리했습니다.  
또한 세션 만료 기준과 검색 결과 저장 로직을 보완하고, 규정 문서 청킹 로직의 후속 피드백도 함께 반영했습니다.

## 변경 사항 (있다면)

- `chat_session` 기반 세션 시작 및 30분 비활성 만료 처리 로직을 추가했습니다.
- `/api/v1/ai/chat`에 `chat_log` 상태 관리, retrieval 결과 저장, citation 추적, `chat_error_log` 적재를 구현했습니다.
- 관리자용 `chat_log` 상세 조회와 최근 세션 조회 API를 추가하고, retrieval 결과 및 error log를 함께 확인할 수 있도록 했습니다.
- 규정 문서 청킹 로직에서 `utcnow` 제거, `COUNT` 쿼리 최적화, 빈 본문 처리 통일, 최대 길이 설정화, 긴 문단 강제 분할을 반영했습니다.

## 리뷰 포인트

- 채팅 요청 시 `PROCESSING -> SUCCESS / NO_ANSWER / ERROR` 상태 전이가 의도대로 동작하는지
- `chat_retrieval_result`와 citation 추적(`selected_as_citation`, `citation_order`)이 답변과 일관되게 저장되는지
- 예외 발생 시 `chat_error_log`가 적절한 `error_type`, `occurred_step`으로 남는지
- 세션 만료 기준과 규정 문서 청킹 보완이 기존 흐름에 부작용 없이 반영됐는지

## 테스트

- [x] 로컬 실행 확인
- [x] `/docs` 수동 확인
- [x] `pytest` 실행

## 스크린샷
### 1. user_id null로 세션 생성
<img width="1402" height="459" alt="스크린샷 2026-04-27 오전 1 11 28" src="https://github.com/user-attachments/assets/b021e8b8-4cdc-4004-ab50-c60a991a8772" />

### 2. 세션으로 챗
<img width="1403" height="538" alt="스크린샷 2026-04-27 오전 12 36 35" src="https://github.com/user-attachments/assets/372bae62-9537-4ae4-85ee-7e44342e4cf5" />

### 3. 챗 로그 조회
<img width="1397" height="533" alt="스크린샷 2026-04-27 오전 12 53 34" src="https://github.com/user-attachments/assets/e482e013-1806-4498-9fda-2eb7d6d851ce" />

### 4. 챗 로그 조회 retrieval_results 자세히
<img width="1394" height="577" alt="스크린샷 2026-04-27 오전 1 41 05" src="https://github.com/user-attachments/assets/ed1d152c-4cd8-456c-94ce-f050ae98efda" />

### 5. 최근 세션 10개 조회
<img width="1405" height="576" alt="스크린샷 2026-04-27 오전 2 24 58" src="https://github.com/user-attachments/assets/061fced0-75ed-4c57-b751-28653b4561bc" />
30분 동안 챗이 없으면 자동으로 만료됩니다. 
