### PR TITLE
[Feat] 규정 문서 타입 조회 API 추가

### DIFF
--- a/alembic/versions/20260427_0011_add_regulation_document_type_expression_index.py
+++ b/alembic/versions/20260427_0011_add_regulation_document_type_expression_index.py
@@ -1,0 +1,32 @@
+"""add regulation_document document_type expression index
+
+Revision ID: 20260427_0011
+Revises: 20260426_0010
+Create Date: 2026-04-27 03:10:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260427_0011"
+down_revision = "20260426_0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_regulation_document_active_document_type_expr",
+        "regulation_document",
+        [sa.text("regexp_replace(document_id, '_[0-9]+$', '')")],
+        unique=False,
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_regulation_document_active_document_type_expr",
+        table_name="regulation_document",
+    )

--- a/app/api/regulations.py
+++ b/app/api/regulations.py
@@ -41,7 +41,7 @@ def get_regulation_document_types_api(
     summary="규정 문서 타입 기준 문서 조회",
 )
 def get_regulation_documents_by_type_api(
-    document_type: str = Query(min_length=1, max_length=100),
+    document_type: str = Query(min_length=1, max_length=100, pattern=r".*\S.*"),
     db: Session = Depends(get_db),
 ) -> ApiResponse[RegulationLookupResult]:
     result = get_regulation_documents_by_type(db, document_type)

--- a/app/api/regulations.py
+++ b/app/api/regulations.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Query
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.schemas.common import ApiResponse
+from app.schemas.regulation_lookup import RegulationDocumentTypeListResult
+from app.schemas.regulation_lookup import RegulationLookupResult
+from app.services.regulation_lookup_service import get_regulation_document_types
+from app.services.regulation_lookup_service import get_regulation_documents_by_type
+
+router = APIRouter(
+    prefix="/regulations",
+    tags=["regulations"],
+)
+
+
+@router.get(
+    "/document-types",
+    response_model=ApiResponse[RegulationDocumentTypeListResult],
+    status_code=status.HTTP_200_OK,
+    summary="조회 가능한 규정 문서 타입 목록 조회",
+)
+def get_regulation_document_types_api(
+    db: Session = Depends(get_db),
+) -> ApiResponse[RegulationDocumentTypeListResult]:
+    result = get_regulation_document_types(db)
+    return ApiResponse(
+        status=status.HTTP_200_OK,
+        message="regulation document types retrieved",
+        data=result,
+    )
+
+
+@router.get(
+    "",
+    response_model=ApiResponse[RegulationLookupResult],
+    status_code=status.HTTP_200_OK,
+    summary="규정 문서 타입 기준 문서 조회",
+)
+def get_regulation_documents_by_type_api(
+    document_type: str = Query(min_length=1, max_length=100),
+    db: Session = Depends(get_db),
+) -> ApiResponse[RegulationLookupResult]:
+    result = get_regulation_documents_by_type(db, document_type)
+    return ApiResponse(
+        status=status.HTTP_200_OK,
+        message="regulation documents retrieved",
+        data=result,
+    )

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.admin_chat import router as admin_chat_router
 from app.api.admin_regulation_documents import router as admin_regulation_documents_router
 from app.api.admin_regulation_chunk_ingestion import router as admin_regulation_chunk_ingestion_router
+from app.api.regulations import router as regulations_router
 
 api_router = APIRouter()
 api_router.include_router(admin_chat_router)
@@ -16,3 +17,4 @@ from app.api.notice import router as notice_router
 
 api_router.include_router(chat_router)
 api_router.include_router(notice_router)
+api_router.include_router(regulations_router)

--- a/app/db/models/regulation_document.py
+++ b/app/db/models/regulation_document.py
@@ -26,6 +26,11 @@ class RegulationDocument(Base):
             "document_version",
             name="uq_regulation_document_doc_ver",
         ),
+        Index(
+            "idx_regulation_document_active_document_type_expr",
+            text("regexp_replace(document_id, '_[0-9]+$', '')"),
+            postgresql_where=text("is_active = true"),
+        ),
         Index("idx_regulation_document_document_id", "document_id"),
         Index("idx_regulation_document_document_version", "document_version"),
         Index("idx_regulation_document_category", "category"),

--- a/app/repositories/regulation_lookup_repository.py
+++ b/app/repositories/regulation_lookup_repository.py
@@ -1,0 +1,54 @@
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models.regulation_document import RegulationDocument
+
+
+DOCUMENT_TYPE_REGEX = r"_[0-9]+$"
+
+
+def list_active_regulation_documents_by_type(
+    db: Session,
+    document_type: str,
+) -> list[RegulationDocument]:
+    resolved_document_type = _document_type_expression()
+    statement = (
+        select(RegulationDocument)
+        .where(
+            resolved_document_type == document_type,
+            RegulationDocument.is_active.is_(True),
+        )
+        .order_by(
+            RegulationDocument.document_id.asc(),
+            RegulationDocument.document_version.asc(),
+            RegulationDocument.regulation_document_id.asc(),
+        )
+    )
+    return list(db.execute(statement).scalars().all())
+
+
+def list_active_regulation_document_types(
+    db: Session,
+) -> list[dict]:
+    resolved_document_type = _document_type_expression()
+    statement = (
+        select(
+            resolved_document_type.label("document_type"),
+            func.count(RegulationDocument.regulation_document_id).label("document_count"),
+        )
+        .where(RegulationDocument.is_active.is_(True))
+        .group_by(resolved_document_type)
+        .order_by(resolved_document_type.asc())
+    )
+    return [
+        {
+            "document_type": row.document_type,
+            "document_count": row.document_count,
+        }
+        for row in db.execute(statement).all()
+    ]
+
+
+def _document_type_expression():
+    return func.regexp_replace(RegulationDocument.document_id, DOCUMENT_TYPE_REGEX, "")

--- a/app/schemas/regulation_lookup.py
+++ b/app/schemas/regulation_lookup.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class RegulationLookupDocument(BaseModel):
+    regulation_document_id: int
+    document_id: str
+    document_version: str
+    document_type: str
+    category: Optional[str] = None
+    dormitory: Optional[str] = None
+    title: Optional[str] = None
+    content: Optional[str] = None
+    source: Optional[str] = None
+    source_url: Optional[str] = None
+    keywords: Optional[list[str]] = None
+    source_type: Optional[str] = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class RegulationLookupResult(BaseModel):
+    document_type: str
+    total_count: int
+    items: list[RegulationLookupDocument]
+
+
+class RegulationDocumentTypeSummary(BaseModel):
+    document_type: str
+    document_count: int
+
+
+class RegulationDocumentTypeListResult(BaseModel):
+    items: list[RegulationDocumentTypeSummary]

--- a/app/services/regulation_lookup_service.py
+++ b/app/services/regulation_lookup_service.py
@@ -13,6 +13,12 @@ def get_regulation_documents_by_type(
     document_type: str,
 ) -> RegulationLookupResult:
     normalized_document_type = document_type.strip()
+    if not normalized_document_type:
+        return RegulationLookupResult(
+            document_type="",
+            total_count=0,
+            items=[],
+        )
     documents = list_active_regulation_documents_by_type(db, normalized_document_type)
     return RegulationLookupResult(
         document_type=normalized_document_type,

--- a/app/services/regulation_lookup_service.py
+++ b/app/services/regulation_lookup_service.py
@@ -1,0 +1,60 @@
+from sqlalchemy.orm import Session
+
+from app.repositories.regulation_lookup_repository import list_active_regulation_documents_by_type
+from app.repositories.regulation_lookup_repository import list_active_regulation_document_types
+from app.schemas.regulation_lookup import RegulationDocumentTypeListResult
+from app.schemas.regulation_lookup import RegulationDocumentTypeSummary
+from app.schemas.regulation_lookup import RegulationLookupDocument
+from app.schemas.regulation_lookup import RegulationLookupResult
+
+
+def get_regulation_documents_by_type(
+    db: Session,
+    document_type: str,
+) -> RegulationLookupResult:
+    normalized_document_type = document_type.strip()
+    documents = list_active_regulation_documents_by_type(db, normalized_document_type)
+    return RegulationLookupResult(
+        document_type=normalized_document_type,
+        total_count=len(documents),
+        items=[_to_lookup_document(document) for document in documents],
+    )
+
+
+def get_regulation_document_types(db: Session) -> RegulationDocumentTypeListResult:
+    return RegulationDocumentTypeListResult(
+        items=[
+            RegulationDocumentTypeSummary(
+                document_type=item["document_type"],
+                document_count=item["document_count"],
+            )
+            for item in list_active_regulation_document_types(db)
+        ]
+    )
+
+
+def _to_lookup_document(document) -> RegulationLookupDocument:
+    return RegulationLookupDocument(
+        regulation_document_id=document.regulation_document_id,
+        document_id=document.document_id,
+        document_version=document.document_version,
+        document_type=_extract_document_type(document.document_id),
+        category=document.category,
+        dormitory=document.dormitory,
+        title=document.title,
+        content=document.content,
+        source=document.source,
+        source_url=document.source_url,
+        keywords=document.keywords,
+        source_type=document.source_type,
+        is_active=document.is_active,
+        created_at=document.created_at,
+        updated_at=document.updated_at,
+    )
+
+
+def _extract_document_type(document_id: str) -> str:
+    if "_" not in document_id:
+        return document_id
+    head, tail = document_id.rsplit("_", 1)
+    return head if tail.isdigit() else document_id

--- a/docs/regulation-document-types.md
+++ b/docs/regulation-document-types.md
@@ -1,0 +1,32 @@
+# Regulation Document Types
+
+`regulation_document.document_id`는 뒤의 숫자 suffix를 제거한 값을 `document_type`으로 취급합니다.
+
+예시:
+- `facility_007` -> `facility`
+- `facility_usage_011` -> `facility_usage`
+- `tips_004` -> `tips`
+
+현재 DB 기준 활성 문서 타입 목록:
+
+| document_type | document_count |
+| --- | ---: |
+| admission | 32 |
+| facility | 24 |
+| facility_usage | 31 |
+| intro | 9 |
+| rules | 21 |
+| tip | 8 |
+| tips | 8 |
+
+조회 API:
+
+```http
+GET /api/v1/regulations/document-types
+GET /api/v1/regulations?document_type=facility
+GET /api/v1/regulations?document_type=facility_usage
+```
+
+비고:
+- `tip`과 `tips`는 현재 DB에 별도 타입으로 함께 존재합니다.
+- 조회 API는 `is_active = true` 문서만 반환합니다.

--- a/docs/트러블슈팅.md
+++ b/docs/트러블슈팅.md
@@ -438,3 +438,44 @@ answer_result = generate_answer(question, labeled_chunks)
 5. 교훈 및 주의 사항
 주의할 점: `refresh()`는 “안전해 보이는 기본 동작”처럼 느껴지지만, 실제로는 쿼리 수를 늘리는 비용이 있으므로 필요한 경우에만 써야 합니다.
 배운 점: 운영 추적이 중요한 시스템에서는 “최종 답변 성공 여부”뿐 아니라 “실패 직전까지 확보한 근거 데이터도 남길 것인가”를 의식적으로 설계해야 합니다.
+
+---
+
+제목 : [regulation 조회/document_type 계산식 조회의 검증·인덱싱 보완] 프로젝트 - 14
+1. 문제 개요
+오류 상황: 규정 문서 조회 API가 `document_type`을 `document_id`에서 계산해서 사용하고 있었는데, 공백 입력에 대한 방어가 약했고 `regexp_replace` 계산식을 그대로 WHERE/GROUP BY에 써서 인덱스 활용성이 떨어질 수 있었습니다.
+발생 배경: PR3 리뷰에서 공백 입력 처리 누락과 계산식 기반 조회 성능 저하 가능성에 대한 피드백이 들어왔습니다.
+2. 오류 코드 및 오류 메시지
+오류 코드: 즉시 드러나는 서버 오류는 없었음
+오류 메시지: 별도 메시지 없음
+관련 로그:
+- `document_type.strip()` 이후 빈 문자열이 될 수 있는 구조
+- `regexp_replace(document_id, '_[0-9]+$', '')`를 WHERE/GROUP BY/ORDER BY에서 직접 사용하는 쿼리
+3. 원인 분석
+오류 원인: 초기 구현에서는 조회 기능 자체를 빠르게 붙이는 데 집중하면서 입력 정규화와 계산식 기반 인덱스 전략이 뒤로 밀렸습니다.
+에러 로그 해석: 런타임 예외가 아니라 API 입력 품질과 DB 실행 계획 관점에서의 잠재 리스크였습니다.
+구조적 이해:
+- 공백 문자열은 `min_length=1`만으로는 막히지 않으므로 별도 패턴 검증이 필요합니다.
+- 일반 인덱스는 원본 `document_id`에는 적용되지만, `regexp_replace(document_id, ...)` 같은 계산식에는 바로 활용되지 않습니다.
+- 이런 경우 functional index나 별도 컬럼 전략 중 하나를 선택해야 합니다.
+4. 해결책
+단계별 조치 방법:
+Step 1: API 쿼리 파라미터에 `pattern`을 추가해 공백-only 입력을 422로 차단했습니다.
+Step 2: 서비스 레벨에서도 `strip()` 결과가 빈 문자열이면 빈 결과를 반환하도록 방어 로직을 추가했습니다.
+Step 3: `regulation_document`에 active 문서만 대상으로 하는 partial functional index를 추가했습니다.
+Step 4: Alembic migration과 DAP.sql 정의도 같은 기준으로 맞췄습니다.
+코드 예시:
+```python
+document_type: str = Query(min_length=1, max_length=100, pattern=r".*\\S.*")
+```
+```sql
+CREATE INDEX idx_regulation_document_active_document_type_expr
+ON regulation_document ((regexp_replace(document_id, '_[0-9]+$', '')))
+WHERE is_active = true;
+```
+추가 자료:
+- https://docs.sqlalchemy.org/en/20/core/constraints.html
+- https://www.postgresql.org/docs/current/indexes-expressional.html
+5. 교훈 및 주의 사항
+주의할 점: 조회 API는 동작만 확인하고 끝내기 쉬운데, 입력 정규화와 인덱스 전략까지 같이 보지 않으면 운영 시점에 병목이 생기기 쉽습니다.
+배운 점: 계산식 기반 조회는 처음부터 “별도 컬럼으로 갈지, functional index로 갈지”를 명확히 정하는 편이 이후 수정 비용을 줄여줍니다.

--- a/tests/test_regulation_lookup_service.py
+++ b/tests/test_regulation_lookup_service.py
@@ -76,3 +76,11 @@ def test_get_regulation_document_types_returns_summaries(monkeypatch) -> None:
     assert len(result.items) == 3
     assert result.items[1].document_type == "facility"
     assert result.items[1].document_count == 24
+
+
+def test_get_regulation_documents_by_type_returns_empty_result_for_blank_input() -> None:
+    result = regulation_lookup_service.get_regulation_documents_by_type(object(), "   ")
+
+    assert result.document_type == ""
+    assert result.total_count == 0
+    assert result.items == []

--- a/tests/test_regulation_lookup_service.py
+++ b/tests/test_regulation_lookup_service.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+from app.services import regulation_lookup_service
+
+
+def test_get_regulation_documents_by_type_returns_mapped_documents(monkeypatch) -> None:
+    documents = [
+        type(
+            "RegulationDocumentStub",
+            (),
+            {
+                "regulation_document_id": 1,
+                "document_id": "facility_007",
+                "document_version": "v1",
+                "category": "시설안내",
+                "dormitory": "제1학생생활관",
+                "title": "제1학생생활관 학생식당 위치",
+                "content": "학생식당은 1층에 있습니다.",
+                "source": "manual",
+                "source_url": "https://example.com/facility_007",
+                "keywords": ["식당"],
+                "source_type": "MARKDOWN",
+                "is_active": True,
+                "created_at": datetime(2026, 4, 27, 10, 0, 0),
+                "updated_at": datetime(2026, 4, 27, 10, 0, 1),
+            },
+        )(),
+        type(
+            "RegulationDocumentStub",
+            (),
+            {
+                "regulation_document_id": 2,
+                "document_id": "facility_008",
+                "document_version": "v1",
+                "category": "시설안내",
+                "dormitory": "제2학생생활관",
+                "title": "제2학생생활관 수용현황",
+                "content": "총 수용 인원 안내",
+                "source": "manual",
+                "source_url": "https://example.com/facility_008",
+                "keywords": None,
+                "source_type": "MARKDOWN",
+                "is_active": True,
+                "created_at": datetime(2026, 4, 27, 10, 0, 2),
+                "updated_at": datetime(2026, 4, 27, 10, 0, 3),
+            },
+        )(),
+    ]
+    monkeypatch.setattr(
+        regulation_lookup_service,
+        "list_active_regulation_documents_by_type",
+        lambda *_args, **_kwargs: documents,
+    )
+
+    result = regulation_lookup_service.get_regulation_documents_by_type(object(), " facility ")
+
+    assert result.document_type == "facility"
+    assert result.total_count == 2
+    assert result.items[0].document_id == "facility_007"
+    assert result.items[0].document_type == "facility"
+
+
+def test_get_regulation_document_types_returns_summaries(monkeypatch) -> None:
+    monkeypatch.setattr(
+        regulation_lookup_service,
+        "list_active_regulation_document_types",
+        lambda *_args, **_kwargs: [
+            {"document_type": "admission", "document_count": 32},
+            {"document_type": "facility", "document_count": 24},
+            {"document_type": "facility_usage", "document_count": 31},
+        ],
+    )
+
+    result = regulation_lookup_service.get_regulation_document_types(object())
+
+    assert len(result.items) == 3
+    assert result.items[1].document_type == "facility"
+    assert result.items[1].document_count == 24

--- a/tests/test_regulations_api.py
+++ b/tests/test_regulations_api.py
@@ -101,3 +101,12 @@ def test_get_regulation_documents_by_type_api_returns_documents(
         },
         "error_code": None,
     }
+
+
+def test_get_regulation_documents_by_type_api_rejects_blank_query(
+    client: TestClient,
+) -> None:
+    response = client.get("/api/v1/regulations?document_type=   ")
+
+    assert response.status_code == 422
+    assert response.json()["error_code"] == "VALIDATION_ERROR"

--- a/tests/test_regulations_api.py
+++ b/tests/test_regulations_api.py
@@ -1,0 +1,103 @@
+from fastapi.testclient import TestClient
+
+from app.api import regulations as regulations_module
+from app.schemas.regulation_lookup import RegulationDocumentTypeListResult
+from app.schemas.regulation_lookup import RegulationDocumentTypeSummary
+from app.schemas.regulation_lookup import RegulationLookupDocument
+from app.schemas.regulation_lookup import RegulationLookupResult
+
+
+def test_get_regulation_document_types_api_returns_list(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        regulations_module,
+        "get_regulation_document_types",
+        lambda *_args, **_kwargs: RegulationDocumentTypeListResult(
+            items=[
+                RegulationDocumentTypeSummary(document_type="admission", document_count=32),
+                RegulationDocumentTypeSummary(document_type="facility", document_count=24),
+            ]
+        ),
+    )
+
+    response = client.get("/api/v1/regulations/document-types")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": 200,
+        "message": "regulation document types retrieved",
+        "data": {
+            "items": [
+                {"document_type": "admission", "document_count": 32},
+                {"document_type": "facility", "document_count": 24},
+            ]
+        },
+        "error_code": None,
+    }
+
+
+def test_get_regulation_documents_by_type_api_returns_documents(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        regulations_module,
+        "get_regulation_documents_by_type",
+        lambda *_args, **_kwargs: RegulationLookupResult(
+            document_type="facility",
+            total_count=1,
+            items=[
+                RegulationLookupDocument(
+                    regulation_document_id=1,
+                    document_id="facility_007",
+                    document_version="v1",
+                    document_type="facility",
+                    category="시설안내",
+                    dormitory="제1학생생활관",
+                    title="제1학생생활관 학생식당 위치",
+                    content="학생식당은 1층에 있습니다.",
+                    source="manual",
+                    source_url="https://example.com/facility_007",
+                    keywords=["식당"],
+                    source_type="MARKDOWN",
+                    is_active=True,
+                    created_at="2026-04-27T10:00:00",
+                    updated_at="2026-04-27T10:00:01",
+                )
+            ],
+        ),
+    )
+
+    response = client.get("/api/v1/regulations?document_type=facility")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": 200,
+        "message": "regulation documents retrieved",
+        "data": {
+            "document_type": "facility",
+            "total_count": 1,
+            "items": [
+                {
+                    "regulation_document_id": 1,
+                    "document_id": "facility_007",
+                    "document_version": "v1",
+                    "document_type": "facility",
+                    "category": "시설안내",
+                    "dormitory": "제1학생생활관",
+                    "title": "제1학생생활관 학생식당 위치",
+                    "content": "학생식당은 1층에 있습니다.",
+                    "source": "manual",
+                    "source_url": "https://example.com/facility_007",
+                    "keywords": ["식당"],
+                    "source_type": "MARKDOWN",
+                    "is_active": True,
+                    "created_at": "2026-04-27T10:00:00",
+                    "updated_at": "2026-04-27T10:00:01",
+                }
+            ],
+        },
+        "error_code": None,
+    }


### PR DESCRIPTION

## 유형

- [x] Feat
- [ ] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

프론트와 관리자가 `document_id` 접두어 기준으로 규정 문서를 조회할 수 있도록 규정 문서 타입 조회 API를 추가했습니다.  
또한 실제 DB에 저장된 문서 타입 목록을 정리한 문서를 함께 추가해, 조회 가능한 타입과 규칙을 명확히 했습니다.

## 변경 사항 (있다면)

- `document_id`의 숫자 suffix를 제거한 `document_type` 기준으로 활성 규정 문서를 조회하는 API를 추가했습니다.
- 조회 가능한 `document_type` 목록을 반환하는 API를 추가했습니다.
- 현재 DB 기준 문서 타입 목록과 규칙을 `docs/regulation-document-types.md`에 정리했습니다.

## 리뷰 포인트

- `facility`, `facility_usage`처럼 `_`가 포함된 타입도 의도대로 구분되는지
- `document_id`에서 숫자 suffix를 제거하는 규칙이 조회 API와 문서 설명에 일관되게 반영됐는지
- 조회 API가 `is_active = true` 문서만 반환하도록 잘 제한되어 있는지

## 테스트

- [x] 로컬 실행 확인
- [x] `/docs` 수동 확인
- [x] `pytest` 실행

## 스크린샷
### 1. 타입 조회
<img width="1398" height="689" alt="image" src="https://github.com/user-attachments/assets/7accd528-eaa8-4c0d-be66-fe32aed4a11a" />

### 2. 단건 조회
<img width="1405" height="687" alt="image" src="https://github.com/user-attachments/assets/c9754812-06fb-4ef3-b089-a98e26978dec" />

