### PR TITLE
[Fix] 관리자 채팅 세션 조회 방식 변경

### DIFF
--- a/app/api/admin_chat.py
+++ b/app/api/admin_chat.py
@@ -1,16 +1,19 @@
+from datetime import date
+
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Path
+from fastapi import Query
 from fastapi import status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.admin_auth import require_admin_token
 from app.db.session import get_db
 from app.schemas.admin_chat import AdminChatLogDetail
-from app.schemas.admin_chat import AdminRecentChatSessionsResult
+from app.schemas.admin_chat import AdminChatSessionsByDateResult
 from app.schemas.common import ApiResponse
+from app.services.admin_chat_service import get_admin_chat_sessions_by_date
 from app.services.admin_chat_service import get_admin_chat_log_detail
-from app.services.admin_chat_service import get_recent_admin_chat_sessions
 
 router = APIRouter(
     prefix="/admin/chat",
@@ -39,18 +42,21 @@ def get_admin_chat_log_api(
 
 
 @router.get(
-    "/sessions/recent",
-    response_model=ApiResponse[AdminRecentChatSessionsResult],
+    "/sessions",
+    response_model=ApiResponse[AdminChatSessionsByDateResult],
     status_code=status.HTTP_200_OK,
-    summary="최신 채팅 세션 10건 조회",
-    description="관리자가 `chat_session` 테이블에서 최근 활동 기준 최신 10개 세션을 조회합니다.",
+    summary="날짜별 채팅 세션 조회",
+    description="관리자가 `started_at` 기준 특정 날짜의 채팅 세션을 페이지 단위로 조회합니다.",
 )
-def get_recent_admin_chat_sessions_api(
+def get_admin_chat_sessions_by_date_api(
+    target_date: date = Query(alias="date"),
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
     db: Session = Depends(get_db),
-) -> ApiResponse[AdminRecentChatSessionsResult]:
-    result = get_recent_admin_chat_sessions(db)
+) -> ApiResponse[AdminChatSessionsByDateResult]:
+    result = get_admin_chat_sessions_by_date(db, target_date=target_date, page=page, size=size)
     return ApiResponse(
         status=status.HTTP_200_OK,
-        message="recent chat sessions retrieved",
+        message="chat sessions retrieved",
         data=result,
     )

--- a/app/repositories/admin_chat_repository.py
+++ b/app/repositories/admin_chat_repository.py
@@ -1,6 +1,11 @@
+from datetime import date
+from datetime import datetime
+from datetime import time
+from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy import desc
+from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -15,10 +20,32 @@ def get_chat_log_by_id(db: Session, chat_log_id: int) -> Optional[ChatLog]:
     return db.execute(statement).scalar_one_or_none()
 
 
-def list_recent_chat_sessions(db: Session, limit: int = 10) -> list[ChatSession]:
+def count_chat_sessions_by_started_date(db: Session, target_date: date) -> int:
+    start_at = datetime.combine(target_date, time.min)
+    end_at = start_at + timedelta(days=1)
+    statement = (
+        select(func.count())
+        .select_from(ChatSession)
+        .where(ChatSession.started_at >= start_at)
+        .where(ChatSession.started_at < end_at)
+    )
+    return int(db.execute(statement).scalar_one())
+
+
+def list_chat_sessions_by_started_date(
+    db: Session,
+    target_date: date,
+    offset: int,
+    limit: int,
+) -> list[ChatSession]:
+    start_at = datetime.combine(target_date, time.min)
+    end_at = start_at + timedelta(days=1)
     statement = (
         select(ChatSession)
+        .where(ChatSession.started_at >= start_at)
+        .where(ChatSession.started_at < end_at)
         .order_by(desc(ChatSession.last_activity_at), desc(ChatSession.started_at))
+        .offset(offset)
         .limit(limit)
     )
     return list(db.execute(statement).scalars().all())

--- a/app/schemas/admin_chat.py
+++ b/app/schemas/admin_chat.py
@@ -1,3 +1,4 @@
+from datetime import date
 from datetime import datetime
 from typing import Optional
 
@@ -54,14 +55,13 @@ class AdminChatSessionSummary(BaseModel):
     started_at: datetime
     ended_at: Optional[datetime] = None
     last_activity_at: datetime
-    entry_point: Optional[str] = None
-    is_returning_user: bool
-    utm_source: Optional[str] = None
-    utm_medium: Optional[str] = None
-    utm_campaign: Optional[str] = None
     created_at: datetime
     is_expired: bool
 
 
-class AdminRecentChatSessionsResult(BaseModel):
+class AdminChatSessionsByDateResult(BaseModel):
+    date: date
+    page: int
+    size: int
+    total_count: int
     items: list[AdminChatSessionSummary]

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from typing import Literal
 from datetime import datetime
 
 from pydantic import BaseModel
@@ -22,11 +21,6 @@ class ChatResponse(BaseModel):
 
 class ChatSessionCreateRequest(BaseModel):
     user_id: Optional[int] = Field(default=None, ge=1)
-    entry_point: Optional[Literal["WEB", "APP", "NOTICE", "FAQ"]] = None
-    is_returning_user: bool = False
-    utm_source: Optional[str] = Field(default=None, max_length=100)
-    utm_medium: Optional[str] = Field(default=None, max_length=100)
-    utm_campaign: Optional[str] = Field(default=None, max_length=100)
 
 
 class ChatSessionCreateResponse(BaseModel):
@@ -36,9 +30,4 @@ class ChatSessionCreateResponse(BaseModel):
     started_at: datetime
     ended_at: Optional[datetime] = None
     last_activity_at: datetime
-    entry_point: Optional[str] = None
-    is_returning_user: bool
-    utm_source: Optional[str] = None
-    utm_medium: Optional[str] = None
-    utm_campaign: Optional[str] = None
     created_at: datetime

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -81,6 +81,9 @@ def get_admin_chat_sessions_by_date(
     offset = (page - 1) * size
     total_count = count_chat_sessions_by_started_date(db, target_date)
     sessions = list_chat_sessions_by_started_date(db, target_date, offset=offset, limit=size)
+    settings = get_settings()
+    expiration_threshold = get_current_utc_time() - timedelta(minutes=settings.chat_session_timeout_minutes)
+
     return AdminChatSessionsByDateResult(
         date=target_date,
         page=page,
@@ -95,14 +98,12 @@ def get_admin_chat_sessions_by_date(
                 ended_at=session.ended_at,
                 last_activity_at=session.last_activity_at,
                 created_at=session.created_at,
-                is_expired=_is_chat_session_expired(session.last_activity_at),
+                is_expired=_is_chat_session_expired(session.last_activity_at, expiration_threshold),
             )
             for session in sessions
         ]
     )
 
 
-def _is_chat_session_expired(last_activity_at: datetime) -> bool:
-    settings = get_settings()
-    expiration_threshold = get_current_utc_time() - timedelta(minutes=settings.chat_session_timeout_minutes)
+def _is_chat_session_expired(last_activity_at: datetime, expiration_threshold: datetime) -> bool:
     return last_activity_at < expiration_threshold

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -1,3 +1,4 @@
+from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
@@ -8,13 +9,14 @@ from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
 from app.core.time_utils import get_current_utc_time
 from app.repositories.admin_chat_repository import get_chat_log_by_id
+from app.repositories.admin_chat_repository import count_chat_sessions_by_started_date
 from app.repositories.admin_chat_repository import list_chat_error_logs_by_chat_log_id
 from app.repositories.admin_chat_repository import list_chat_retrieval_results_by_chat_log_id
-from app.repositories.admin_chat_repository import list_recent_chat_sessions
+from app.repositories.admin_chat_repository import list_chat_sessions_by_started_date
 from app.schemas.admin_chat import AdminChatErrorLog
+from app.schemas.admin_chat import AdminChatSessionsByDateResult
 from app.schemas.admin_chat import AdminChatLogDetail
 from app.schemas.admin_chat import AdminChatRetrievalResult
-from app.schemas.admin_chat import AdminRecentChatSessionsResult
 from app.schemas.admin_chat import AdminChatSessionSummary
 
 
@@ -70,9 +72,20 @@ def get_admin_chat_log_detail(db: Session, chat_log_id: int) -> AdminChatLogDeta
     )
 
 
-def get_recent_admin_chat_sessions(db: Session) -> AdminRecentChatSessionsResult:
-    sessions = list_recent_chat_sessions(db, limit=10)
-    return AdminRecentChatSessionsResult(
+def get_admin_chat_sessions_by_date(
+    db: Session,
+    target_date: date,
+    page: int,
+    size: int,
+) -> AdminChatSessionsByDateResult:
+    offset = (page - 1) * size
+    total_count = count_chat_sessions_by_started_date(db, target_date)
+    sessions = list_chat_sessions_by_started_date(db, target_date, offset=offset, limit=size)
+    return AdminChatSessionsByDateResult(
+        date=target_date,
+        page=page,
+        size=size,
+        total_count=total_count,
         items=[
             AdminChatSessionSummary(
                 session_id=session.session_id,
@@ -81,11 +94,6 @@ def get_recent_admin_chat_sessions(db: Session) -> AdminRecentChatSessionsResult
                 started_at=session.started_at,
                 ended_at=session.ended_at,
                 last_activity_at=session.last_activity_at,
-                entry_point=session.entry_point,
-                is_returning_user=session.is_returning_user,
-                utm_source=session.utm_source,
-                utm_medium=session.utm_medium,
-                utm_campaign=session.utm_campaign,
                 created_at=session.created_at,
                 is_expired=_is_chat_session_expired(session.last_activity_at),
             )

--- a/app/services/chat_session_service.py
+++ b/app/services/chat_session_service.py
@@ -15,11 +15,6 @@ def start_chat_session(
         db,
         session_id=str(uuid4()),
         user_id=payload.user_id,
-        entry_point=payload.entry_point,
-        is_returning_user=payload.is_returning_user,
-        utm_source=payload.utm_source,
-        utm_medium=payload.utm_medium,
-        utm_campaign=payload.utm_campaign,
     )
     db.commit()
     db.refresh(chat_session)
@@ -31,10 +26,5 @@ def start_chat_session(
         started_at=chat_session.started_at,
         ended_at=chat_session.ended_at,
         last_activity_at=chat_session.last_activity_at,
-        entry_point=chat_session.entry_point,
-        is_returning_user=chat_session.is_returning_user,
-        utm_source=chat_session.utm_source,
-        utm_medium=chat_session.utm_medium,
-        utm_campaign=chat_session.utm_campaign,
         created_at=chat_session.created_at,
     )

--- a/tests/test_admin_chat_api.py
+++ b/tests/test_admin_chat_api.py
@@ -6,7 +6,7 @@ from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
 from app.schemas.admin_chat import AdminChatLogDetail
 from app.schemas.admin_chat import AdminChatSessionSummary
-from app.schemas.admin_chat import AdminRecentChatSessionsResult
+from app.schemas.admin_chat import AdminChatSessionsByDateResult
 
 
 def test_get_admin_chat_log_api_returns_chat_log_detail(
@@ -137,14 +137,18 @@ def test_get_admin_chat_log_api_returns_not_found_error(
     }
 
 
-def test_get_recent_admin_chat_sessions_api_returns_latest_10(
+def test_get_admin_chat_sessions_by_date_api_returns_paginated_sessions(
     client: TestClient,
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
         admin_chat_module,
-        "get_recent_admin_chat_sessions",
-        lambda *_args, **_kwargs: AdminRecentChatSessionsResult(
+        "get_admin_chat_sessions_by_date",
+        lambda *_args, **_kwargs: AdminChatSessionsByDateResult(
+            date="2026-04-27",
+            page=1,
+            size=20,
+            total_count=2,
             items=[
                 AdminChatSessionSummary(
                     session_id="session-123",
@@ -153,11 +157,6 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     started_at="2026-04-27T09:30:00",
                     ended_at=None,
                     last_activity_at="2026-04-27T10:00:00",
-                    entry_point="WEB",
-                    is_returning_user=True,
-                    utm_source="newsletter",
-                    utm_medium="email",
-                    utm_campaign="spring",
                     created_at="2026-04-27T09:30:00",
                     is_expired=False,
                 ),
@@ -168,11 +167,6 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     started_at="2026-04-27T09:00:00",
                     ended_at=None,
                     last_activity_at="2026-04-27T09:10:00",
-                    entry_point=None,
-                    is_returning_user=False,
-                    utm_source=None,
-                    utm_medium=None,
-                    utm_campaign=None,
                     created_at="2026-04-27T09:00:00",
                     is_expired=True,
                 ),
@@ -181,15 +175,19 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
     )
 
     response = client.get(
-        "/api/v1/admin/chat/sessions/recent",
+        "/api/v1/admin/chat/sessions?date=2026-04-27&page=1&size=20",
         headers={"X-Admin-Token": "test-admin-token"},
     )
 
     assert response.status_code == 200
     assert response.json() == {
         "status": 200,
-        "message": "recent chat sessions retrieved",
+        "message": "chat sessions retrieved",
         "data": {
+            "date": "2026-04-27",
+            "page": 1,
+            "size": 20,
+            "total_count": 2,
             "items": [
                 {
                     "session_id": "session-123",
@@ -198,11 +196,6 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     "started_at": "2026-04-27T09:30:00",
                     "ended_at": None,
                     "last_activity_at": "2026-04-27T10:00:00",
-                    "entry_point": "WEB",
-                    "is_returning_user": True,
-                    "utm_source": "newsletter",
-                    "utm_medium": "email",
-                    "utm_campaign": "spring",
                     "created_at": "2026-04-27T09:30:00",
                     "is_expired": False,
                 },
@@ -213,11 +206,6 @@ def test_get_recent_admin_chat_sessions_api_returns_latest_10(
                     "started_at": "2026-04-27T09:00:00",
                     "ended_at": None,
                     "last_activity_at": "2026-04-27T09:10:00",
-                    "entry_point": None,
-                    "is_returning_user": False,
-                    "utm_source": None,
-                    "utm_medium": None,
-                    "utm_campaign": None,
                     "created_at": "2026-04-27T09:00:00",
                     "is_expired": True,
                 },

--- a/tests/test_admin_chat_service.py
+++ b/tests/test_admin_chat_service.py
@@ -90,7 +90,7 @@ def test_get_admin_chat_log_detail_raises_not_found(monkeypatch: pytest.MonkeyPa
     assert exc_info.value.error_code.code == "CHAT_LOG_NOT_FOUND"
 
 
-def test_get_recent_admin_chat_sessions_returns_up_to_10(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_admin_chat_sessions_by_date_returns_paginated_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     sessions = [
         type(
             "ChatSessionStub",
@@ -102,11 +102,6 @@ def test_get_recent_admin_chat_sessions_returns_up_to_10(monkeypatch: pytest.Mon
                 "started_at": datetime(2026, 4, 27, 9, 30, 0),
                 "ended_at": None,
                 "last_activity_at": datetime(2026, 4, 27, 10, 0, 0),
-                "entry_point": "WEB",
-                "is_returning_user": True,
-                "utm_source": "newsletter",
-                "utm_medium": "email",
-                "utm_campaign": "spring",
                 "created_at": datetime(2026, 4, 27, 9, 30, 0),
             },
         )(),
@@ -120,21 +115,32 @@ def test_get_recent_admin_chat_sessions_returns_up_to_10(monkeypatch: pytest.Mon
                 "started_at": datetime(2026, 4, 27, 9, 0, 0),
                 "ended_at": None,
                 "last_activity_at": datetime(2026, 4, 27, 9, 10, 0),
-                "entry_point": None,
-                "is_returning_user": False,
-                "utm_source": None,
-                "utm_medium": None,
-                "utm_campaign": None,
                 "created_at": datetime(2026, 4, 27, 9, 0, 0),
             },
         )(),
     ]
-    monkeypatch.setattr(admin_chat_service, "list_recent_chat_sessions", lambda *_args, **_kwargs: sessions)
+    list_calls: dict[str, object] = {}
+    monkeypatch.setattr(admin_chat_service, "count_chat_sessions_by_started_date", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(
+        admin_chat_service,
+        "list_chat_sessions_by_started_date",
+        lambda *_args, **kwargs: list_calls.update(kwargs) or sessions,
+    )
     monkeypatch.setattr(admin_chat_service, "get_settings", lambda: type("SettingsStub", (), {"chat_session_timeout_minutes": 30})())
     monkeypatch.setattr(admin_chat_service, "get_current_utc_time", lambda: datetime(2026, 4, 27, 10, 0, 1))
 
-    result = admin_chat_service.get_recent_admin_chat_sessions(object())
+    result = admin_chat_service.get_admin_chat_sessions_by_date(
+        object(),
+        target_date=datetime(2026, 4, 27).date(),
+        page=2,
+        size=10,
+    )
 
+    assert result.date == datetime(2026, 4, 27).date()
+    assert result.page == 2
+    assert result.size == 10
+    assert result.total_count == 12
+    assert list_calls == {"offset": 10, "limit": 10}
     assert len(result.items) == 2
     assert result.items[0].session_id == "session-123"
     assert result.items[1].session_id == "session-456"

--- a/tests/test_chat_session_api.py
+++ b/tests/test_chat_session_api.py
@@ -18,33 +18,23 @@ def test_start_chat_session_api_returns_created_response(
             started_at="2026-04-26T10:00:00",
             ended_at=None,
             last_activity_at="2026-04-26T10:00:00",
-            entry_point="WEB",
-            is_returning_user=True,
-            utm_source="newsletter",
-            utm_medium="email",
-            utm_campaign="spring",
             created_at="2026-04-26T10:00:00",
         ),
     )
 
     response = client.post(
         "/api/v1/ai/chat/sessions",
-        json={
-            "user_id": 7,
-            "entry_point": "WEB",
-            "is_returning_user": True,
-            "utm_source": "newsletter",
-            "utm_medium": "email",
-            "utm_campaign": "spring",
-        },
+        json={"user_id": 7},
     )
 
     assert response.status_code == 200
     assert response.json()["session_id"] == "session-123"
     assert response.json()["user_id"] == 7
     assert response.json()["total_turns"] == 0
-    assert response.json()["entry_point"] == "WEB"
-    assert response.json()["is_returning_user"] is True
+    assert response.json()["started_at"] == "2026-04-26T10:00:00"
+    assert response.json()["ended_at"] is None
+    assert response.json()["last_activity_at"] == "2026-04-26T10:00:00"
+    assert response.json()["created_at"] == "2026-04-26T10:00:00"
 
 
 def test_start_chat_session_api_accepts_empty_body(
@@ -61,11 +51,6 @@ def test_start_chat_session_api_accepts_empty_body(
             started_at="2026-04-26T10:00:00",
             ended_at=None,
             last_activity_at="2026-04-26T10:00:00",
-            entry_point=None,
-            is_returning_user=False,
-            utm_source=None,
-            utm_medium=None,
-            utm_campaign=None,
             created_at="2026-04-26T10:00:00",
         ),
     )
@@ -78,3 +63,8 @@ def test_start_chat_session_api_accepts_empty_body(
     assert response.status_code == 200
     assert response.json()["session_id"] == "session-456"
     assert response.json()["user_id"] is None
+    assert response.json()["total_turns"] == 0
+    assert response.json()["started_at"] == "2026-04-26T10:00:00"
+    assert response.json()["ended_at"] is None
+    assert response.json()["last_activity_at"] == "2026-04-26T10:00:00"
+    assert response.json()["created_at"] == "2026-04-26T10:00:00"

--- a/tests/test_chat_session_service.py
+++ b/tests/test_chat_session_service.py
@@ -28,11 +28,6 @@ def test_start_chat_session_returns_created_session(monkeypatch) -> None:
             "started_at": datetime(2026, 4, 26, 10, 0, 0),
             "ended_at": None,
             "last_activity_at": datetime(2026, 4, 26, 10, 0, 0),
-            "entry_point": "WEB",
-            "is_returning_user": True,
-            "utm_source": "newsletter",
-            "utm_medium": "email",
-            "utm_campaign": "spring",
             "created_at": datetime(2026, 4, 26, 10, 0, 0),
         },
     )()
@@ -45,21 +40,15 @@ def test_start_chat_session_returns_created_session(monkeypatch) -> None:
 
     result = chat_session_service.start_chat_session(
         db,
-        ChatSessionCreateRequest(
-            user_id=7,
-            entry_point="WEB",
-            is_returning_user=True,
-            utm_source="newsletter",
-            utm_medium="email",
-            utm_campaign="spring",
-        ),
+        ChatSessionCreateRequest(user_id=7),
     )
 
     assert result.session_id == "session-123"
     assert result.user_id == 7
     assert result.total_turns == 0
-    assert result.entry_point == "WEB"
-    assert result.is_returning_user is True
-    assert result.utm_source == "newsletter"
+    assert result.started_at == datetime(2026, 4, 26, 10, 0, 0)
+    assert result.ended_at is None
+    assert result.last_activity_at == datetime(2026, 4, 26, 10, 0, 0)
+    assert result.created_at == datetime(2026, 4, 26, 10, 0, 0)
     assert db.commit_called is True
     assert db.refresh_called is True


### PR DESCRIPTION
## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

# 작업 내용

관리자 채팅 세션 조회 API를 최신 10건 조회 방식에서 날짜별 조회 방식으로 변경했습니다.  
세션 생성 API에서는 현재 사용하지 않는 마케팅/유입 분석 필드를 제거했습니다.

## 변경 사항

- 관리자 채팅 세션 조회 API 변경
  - 기존: `GET /api/v1/admin/chat/sessions/recent`
  - 변경: `GET /api/v1/admin/chat/sessions?date=YYYY-MM-DD&page=1&size=20`
  - `started_at` 기준으로 특정 날짜의 세션을 조회하도록 변경
  - `page`, `size`, `total_count`를 응답에 포함

- 관리자 세션 응답 필드 정리
  - `entry_point`, `is_returning_user`, `utm_source`, `utm_medium`, `utm_campaign` 제거
  - 현재 운영에 필요한 세션 정보만 응답하도록 정리

- 채팅 세션 생성 DTO 정리
  - 요청 DTO에서 `entry_point`, `is_returning_user`, `utm_source`, `utm_medium`, `utm_campaign` 제거
  - 서비스 로직도 제거된 필드를 참조하지 않도록 수정

- 테스트 수정
  - 날짜별 관리자 세션 조회 API/service 테스트 반영
  - 세션 생성 request/response DTO 변경사항 반영



## 테스트

- [x] 로컬 실행 확인
- [x] `/docs` 수동 확인
- [x] `pytest` 실행

## 스크린샷
<img width="657" height="578" alt="스크린샷 2026-04-30 오전 10 19 12" src="https://github.com/user-attachments/assets/552c18bc-79d1-45fe-bb28-1cca5adccbaf" />
