### PR TITLE
[Feat] 사용자 피드백 저장 API 추가

### DIFF
--- a/app/api/chat.py
+++ b/app/api/chat.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from app.schemas.chat import ChatFeedbackCreateRequest, ChatFeedbackCreateResponse
 from app.schemas.chat import ChatRequest, ChatResponse
 from app.schemas.chat import ChatSessionCreateRequest, ChatSessionCreateResponse
+from app.services.chat_feedback_service import create_feedback
 from app.services.chat_service import answer_chat_question
 from app.services.chat_session_service import start_chat_session
 from app.db.session import get_db
@@ -24,6 +26,30 @@ def start_chat_session_api(
     db: Session = Depends(get_db),
 ):
     return start_chat_session(db, request)
+
+
+@router.post(
+    "/feedback",
+    response_model=ChatFeedbackCreateResponse,
+    summary="챗봇 답변 피드백 저장",
+    description=(
+        "특정 `chat_log_id`에 대해 사용자가 답변이 도움이 되었는지 저장합니다.\n\n"
+        "`reason_code`와 `feedback_comment`는 선택값이며, 불만족 사유나 추가 의견이 있을 때만 전달합니다.\n\n"
+        "reason_code 목록:\n"
+        "- `INCORRECT_ANSWER`: 답변이 질문과 다르거나 틀림\n"
+        "- `BAD_CITATION`: 근거/출처가 부정확함\n"
+        "- `TOO_LONG`: 답변이 너무 김\n"
+        "- `TOO_VAGUE`: 답변이 모호함\n"
+        "- `OUTDATED_INFO`: 정보가 오래됨\n"
+        "- `NO_SOURCE`: 출처가 없음\n"
+        "- `OTHER`: 기타"
+    ),
+)
+def create_chat_feedback_api(
+    request: ChatFeedbackCreateRequest,
+    db: Session = Depends(get_db),
+):
+    return create_feedback(db, request)
 
 
 @router.post("", response_model=ChatResponse)

--- a/app/repositories/chat_feedback_repository.py
+++ b/app/repositories/chat_feedback_repository.py
@@ -27,5 +27,4 @@ def create_chat_feedback(
     )
     db.add(chat_feedback)
     db.flush()
-    db.refresh(chat_feedback)
     return chat_feedback

--- a/app/repositories/chat_feedback_repository.py
+++ b/app/repositories/chat_feedback_repository.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.db.models.chat_feedback import ChatFeedback
+
+
+def create_chat_feedback(
+    db: Session,
+    *,
+    chat_log_id: int,
+    user_id: Optional[int],
+    feedback_type: str,
+    is_helpful: bool,
+    reason_code: Optional[str],
+    feedback_comment: Optional[str],
+    feature_type: str = "FAQ_CHAT",
+) -> ChatFeedback:
+    chat_feedback = ChatFeedback(
+        chat_log_id=chat_log_id,
+        user_id=user_id,
+        feedback_type=feedback_type,
+        is_helpful=is_helpful,
+        reason_code=reason_code,
+        feedback_comment=feedback_comment,
+        feature_type=feature_type,
+    )
+    db.add(chat_feedback)
+    db.flush()
+    db.refresh(chat_feedback)
+    return chat_feedback

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from typing import Literal
 from typing import Optional
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ChatRequest(BaseModel):

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -53,8 +53,8 @@ class ChatFeedbackCreateResponse(BaseModel):
     feedback_id: int
     chat_log_id: int
     is_helpful: bool
-    feedback_type: str
-    reason_code: Optional[str] = None
+    feedback_type: Literal["LIKE", "DISLIKE", "RATING"]
+    reason_code: Optional[ChatFeedbackReasonCode] = None
     feedback_comment: Optional[str] = None
     created_at: datetime
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,5 +1,6 @@
-from typing import Optional
 from datetime import datetime
+from typing import Literal
+from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -17,6 +18,46 @@ class ChatResponse(BaseModel):
     answer: str
     answer_status: str
     source_url: str
+
+
+ChatFeedbackReasonCode = Literal[
+    "INCORRECT_ANSWER",
+    "BAD_CITATION",
+    "TOO_LONG",
+    "TOO_VAGUE",
+    "OUTDATED_INFO",
+    "NO_SOURCE",
+    "OTHER",
+]
+
+
+class ChatFeedbackCreateRequest(BaseModel):
+    chat_log_id: int = Field(ge=1)
+    is_helpful: bool
+    reason_code: Optional[ChatFeedbackReasonCode] = Field(
+        default=None,
+        description=(
+            "불만족 사유 코드입니다. "
+            "INCORRECT_ANSWER=답변이 질문과 다르거나 틀림, "
+            "BAD_CITATION=근거/출처가 부정확함, "
+            "TOO_LONG=답변이 너무 김, "
+            "TOO_VAGUE=답변이 모호함, "
+            "OUTDATED_INFO=정보가 오래됨, "
+            "NO_SOURCE=출처가 없음, "
+            "OTHER=기타"
+        ),
+    )
+    feedback_comment: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ChatFeedbackCreateResponse(BaseModel):
+    feedback_id: int
+    chat_log_id: int
+    is_helpful: bool
+    feedback_type: str
+    reason_code: Optional[str] = None
+    feedback_comment: Optional[str] = None
+    created_at: datetime
 
 
 class ChatSessionCreateRequest(BaseModel):

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -48,6 +48,12 @@ class ChatFeedbackCreateRequest(BaseModel):
     )
     feedback_comment: Optional[str] = Field(default=None, max_length=2000)
 
+    @model_validator(mode="after")
+    def validate_negative_feedback_fields(self) -> "ChatFeedbackCreateRequest":
+        if self.is_helpful and (self.reason_code is not None or self.feedback_comment is not None):
+            raise ValueError("reason_code and feedback_comment should only be provided for negative feedback.")
+        return self
+
 
 class ChatFeedbackCreateResponse(BaseModel):
     feedback_id: int

--- a/app/services/chat_feedback_service.py
+++ b/app/services/chat_feedback_service.py
@@ -1,0 +1,40 @@
+from sqlalchemy.orm import Session
+
+from app.core.error_codes import CHAT_LOG_NOT_FOUND
+from app.core.exceptions import AppException
+from app.repositories.chat_feedback_repository import create_chat_feedback
+from app.repositories.chat_log_repository import get_chat_log_by_id
+from app.schemas.chat import ChatFeedbackCreateRequest
+from app.schemas.chat import ChatFeedbackCreateResponse
+
+
+def create_feedback(
+    db: Session,
+    request: ChatFeedbackCreateRequest,
+) -> ChatFeedbackCreateResponse:
+    chat_log = get_chat_log_by_id(db, request.chat_log_id)
+    if chat_log is None:
+        raise AppException(CHAT_LOG_NOT_FOUND)
+
+    feedback_type = "LIKE" if request.is_helpful else "DISLIKE"
+    feedback = create_chat_feedback(
+        db,
+        chat_log_id=request.chat_log_id,
+        user_id=chat_log.user_id,
+        feedback_type=feedback_type,
+        is_helpful=request.is_helpful,
+        reason_code=request.reason_code,
+        feedback_comment=request.feedback_comment,
+    )
+    db.commit()
+    db.refresh(feedback)
+
+    return ChatFeedbackCreateResponse(
+        feedback_id=feedback.feedback_id,
+        chat_log_id=feedback.chat_log_id,
+        is_helpful=bool(feedback.is_helpful),
+        feedback_type=feedback.feedback_type,
+        reason_code=feedback.reason_code,
+        feedback_comment=feedback.feedback_comment,
+        created_at=feedback.created_at,
+    )

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from app.api import chat as chat_module
@@ -143,3 +144,27 @@ def test_chat_feedback_api_accepts_optional_reason_fields(
     assert response.status_code == 200
     assert response.json()["reason_code"] is None
     assert response.json()["feedback_comment"] is None
+
+
+def test_chat_feedback_api_rejects_positive_feedback_reason_fields(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_module,
+        "create_feedback",
+        lambda *_args, **_kwargs: pytest.fail("invalid feedback should not call service"),
+    )
+
+    response = client.post(
+        "/api/v1/ai/chat/feedback",
+        json={
+            "chat_log_id": 101,
+            "is_helpful": True,
+            "reason_code": "OTHER",
+            "feedback_comment": "좋았지만 의견을 남깁니다.",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error_code"] == "VALIDATION_ERROR"

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from app.api import chat as chat_module
 from app.core.error_codes import CHAT_SESSION_EXPIRED
 from app.core.exceptions import AppException
+from app.schemas.chat import ChatFeedbackCreateResponse
 from app.schemas.chat import ChatResponse
 
 
@@ -71,3 +72,74 @@ def test_chat_api_returns_common_error_response_for_expired_session(
         "data": None,
         "error_code": "CHAT_SESSION_EXPIRED",
     }
+
+
+def test_chat_feedback_api_returns_service_response(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_module,
+        "create_feedback",
+        lambda *_args, **_kwargs: ChatFeedbackCreateResponse(
+            feedback_id=501,
+            chat_log_id=101,
+            is_helpful=False,
+            feedback_type="DISLIKE",
+            reason_code="INCORRECT_ANSWER",
+            feedback_comment="택배 위치를 물었는데 외박 안내가 나왔어요.",
+            created_at="2026-04-30T10:00:00",
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/ai/chat/feedback",
+        json={
+            "chat_log_id": 101,
+            "is_helpful": False,
+            "reason_code": "INCORRECT_ANSWER",
+            "feedback_comment": "택배 위치를 물었는데 외박 안내가 나왔어요.",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "feedback_id": 501,
+        "chat_log_id": 101,
+        "is_helpful": False,
+        "feedback_type": "DISLIKE",
+        "reason_code": "INCORRECT_ANSWER",
+        "feedback_comment": "택배 위치를 물었는데 외박 안내가 나왔어요.",
+        "created_at": "2026-04-30T10:00:00",
+    }
+
+
+def test_chat_feedback_api_accepts_optional_reason_fields(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_module,
+        "create_feedback",
+        lambda *_args, **_kwargs: ChatFeedbackCreateResponse(
+            feedback_id=502,
+            chat_log_id=101,
+            is_helpful=True,
+            feedback_type="LIKE",
+            reason_code=None,
+            feedback_comment=None,
+            created_at="2026-04-30T10:00:00",
+        ),
+    )
+
+    response = client.post(
+        "/api/v1/ai/chat/feedback",
+        json={
+            "chat_log_id": 101,
+            "is_helpful": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["reason_code"] is None
+    assert response.json()["feedback_comment"] is None

--- a/tests/test_chat_feedback_service.py
+++ b/tests/test_chat_feedback_service.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+
+import pytest
+
+from app.core.error_codes import CHAT_LOG_NOT_FOUND
+from app.core.exceptions import AppException
+from app.schemas.chat import ChatFeedbackCreateRequest
+from app.services import chat_feedback_service
+
+
+def test_create_feedback_stores_dislike_feedback(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {}
+    chat_log = type("ChatLogStub", (), {"chat_log_id": 101, "user_id": 7})()
+    created_at = datetime(2026, 4, 30, 10, 0, 0)
+    feedback = type(
+        "ChatFeedbackStub",
+        (),
+        {
+            "feedback_id": 501,
+            "chat_log_id": 101,
+            "is_helpful": False,
+            "feedback_type": "DISLIKE",
+            "reason_code": "INCORRECT_ANSWER",
+            "feedback_comment": "택배 위치를 물었는데 외박 안내가 나왔어요.",
+            "created_at": created_at,
+        },
+    )()
+
+    class FakeDb:
+        def commit(self):
+            calls["committed"] = True
+
+        def refresh(self, item):
+            calls["refreshed"] = item
+
+    def fake_create_chat_feedback(_db, **kwargs):
+        calls.update(kwargs)
+        return feedback
+
+    monkeypatch.setattr(chat_feedback_service, "get_chat_log_by_id", lambda *_args: chat_log)
+    monkeypatch.setattr(chat_feedback_service, "create_chat_feedback", fake_create_chat_feedback)
+
+    response = chat_feedback_service.create_feedback(
+        FakeDb(),
+        ChatFeedbackCreateRequest(
+            chat_log_id=101,
+            is_helpful=False,
+            reason_code="INCORRECT_ANSWER",
+            feedback_comment="택배 위치를 물었는데 외박 안내가 나왔어요.",
+        ),
+    )
+
+    assert calls["chat_log_id"] == 101
+    assert calls["user_id"] == 7
+    assert calls["feedback_type"] == "DISLIKE"
+    assert calls["is_helpful"] is False
+    assert calls["reason_code"] == "INCORRECT_ANSWER"
+    assert calls["feedback_comment"] == "택배 위치를 물었는데 외박 안내가 나왔어요."
+    assert calls["committed"] is True
+    assert calls["refreshed"] is feedback
+    assert response.feedback_id == 501
+    assert response.chat_log_id == 101
+    assert response.is_helpful is False
+    assert response.feedback_type == "DISLIKE"
+
+
+def test_create_feedback_stores_like_feedback_without_optional_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {}
+    chat_log = type("ChatLogStub", (), {"chat_log_id": 101, "user_id": None})()
+    feedback = type(
+        "ChatFeedbackStub",
+        (),
+        {
+            "feedback_id": 502,
+            "chat_log_id": 101,
+            "is_helpful": True,
+            "feedback_type": "LIKE",
+            "reason_code": None,
+            "feedback_comment": None,
+            "created_at": datetime(2026, 4, 30, 10, 0, 0),
+        },
+    )()
+
+    class FakeDb:
+        def commit(self):
+            calls["committed"] = True
+
+        def refresh(self, item):
+            calls["refreshed"] = item
+
+    def fake_create_chat_feedback(_db, **kwargs):
+        calls.update(kwargs)
+        return feedback
+
+    monkeypatch.setattr(chat_feedback_service, "get_chat_log_by_id", lambda *_args: chat_log)
+    monkeypatch.setattr(chat_feedback_service, "create_chat_feedback", fake_create_chat_feedback)
+
+    response = chat_feedback_service.create_feedback(
+        FakeDb(),
+        ChatFeedbackCreateRequest(chat_log_id=101, is_helpful=True),
+    )
+
+    assert calls["feedback_type"] == "LIKE"
+    assert calls["reason_code"] is None
+    assert calls["feedback_comment"] is None
+    assert response.is_helpful is True
+    assert response.feedback_type == "LIKE"
+
+
+def test_create_feedback_raises_when_chat_log_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(chat_feedback_service, "get_chat_log_by_id", lambda *_args: None)
+    monkeypatch.setattr(
+        chat_feedback_service,
+        "create_chat_feedback",
+        lambda *_args, **_kwargs: pytest.fail("missing chat log should not create feedback"),
+    )
+
+    with pytest.raises(AppException) as exc_info:
+        chat_feedback_service.create_feedback(
+            object(),
+            ChatFeedbackCreateRequest(chat_log_id=999, is_helpful=False),
+        )
+
+    assert exc_info.value.error_code == CHAT_LOG_NOT_FOUND


### PR DESCRIPTION
## 유형

- [x] Feat
- [ ] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

사용자가 챗봇의 답변을 평가하여 긍정적, 부정적 피드백을 주는 피드백 저장 api를 만들었습니다.
reason_code와 feedback_comment는 부정적 피드백일때만 사용합니다. nullable type

- reason_code 목록
INCORRECT_ANSWER = 답변이 질문과 다르거나 틀림
BAD_CITATION = 근거/출처가 부정확함
TOO_LONG = 답변이 너무 김
TOO_VAGUE = 답변이 모호함
OUTDATED_INFO = 정보가 오래됨
NO_SOURCE = 출처가 없음
OTHER = 기타


## 변경 사항 (있다면)

- POST /api/v1/ai/chat/feedback API 추가
- chat_feedback 저장 로직 추가
- 관련 테스트 추가


## 테스트

- [x] 로컬 실행 확인
- [x] `/docs` 수동 확인
- [x] `pytest` 실행

## 스크린샷

<img width="663" height="511" alt="스크린샷 2026-04-30 오전 10 56 14" src="https://github.com/user-attachments/assets/4ae41d1c-e8e5-4fb8-891f-2829e4fe88d0" />
