### PR TITLE
fix: improve dormitory fallback retrieval(생활관 fallback 검색 로직 개선)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -32,6 +32,12 @@ class Settings(BaseSettings):
     regulation_chunk_max_length: int = 400
     chat_session_timeout_minutes: int = 30
 
+    chat_fallback_top_k: int = 5
+    chat_retrieval_method_fallback: str = "vector_all_dormitories_fallback"
+    chat_retrieval_version_fallback: str = "dormitory-search-fallback-v1"
+
+    chat_fallback_similarity_threshold: float = 0.35
+
 
 @lru_cache
 def get_settings() -> Settings:
@@ -44,3 +50,4 @@ def get_settings() -> Settings:
 
 
 Settings.model_config = SettingsConfigDict(extra="ignore")
+

--- a/app/repositories/regulation_chunk_repository.py
+++ b/app/repositories/regulation_chunk_repository.py
@@ -206,3 +206,59 @@ def search_similar_chunks_for_dormitories(
         }
         for row in result
     ]
+
+
+def search_similar_chunks_all_dormitories(
+    db: Session,
+    query_embedding: list[float],
+    top_k: int = 5,
+):
+    """생활관 필터 없이 전체 활성 regulation_chunk를 대상으로 pgvector 검색합니다."""
+
+    embedding_str = "[" + ",".join(map(str, query_embedding)) + "]"
+
+    sql = text(
+        """
+        SELECT
+            rc.regulation_chunk_id,
+            rd.document_id,
+            rd.document_version,
+            rc.chunk_id,
+            COALESCE(rc.chunk_text, rd.content, '') AS content,
+            rd.source,
+            rd.source_url,
+            rd.dormitory,
+            1 - (rc.embedding <=> CAST(:embedding AS vector)) AS similarity
+        FROM regulation_chunk rc
+        JOIN regulation_document rd
+          ON rd.regulation_document_id = rc.regulation_document_id
+        WHERE rc.is_active = TRUE
+          AND rd.is_active = TRUE
+          AND rc.embedding IS NOT NULL
+        ORDER BY rc.embedding <=> CAST(:embedding AS vector)
+        LIMIT :top_k
+        """
+    )
+
+    result = db.execute(
+        sql,
+        {
+            "embedding": embedding_str,
+            "top_k": top_k,
+        },
+    ).mappings().all()
+
+    return [
+        {
+            "regulation_chunk_id": row.regulation_chunk_id,
+            "document_id": row.document_id,
+            "document_version": row.document_version,
+            "chunk_id": row.chunk_id,
+            "content": row.content,
+            "source": row.source,
+            "source_url": row.source_url,
+            "retrieval_group": row.dormitory,
+            "similarity": float(row.similarity),
+        }
+        for row in result
+    ]

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -167,7 +167,7 @@ def _answer_single_dormitory_chat(
             top_k=settings.chat_single_dormitory_top_k,
         )
 
-
+        # 1차 검색 결과가 없거나 유사도가 낮으면 전체 생활관 fallback 검색
         if _should_fallback_retrieval(chunks):
             chunks = search_similar_chunks_all_dormitories(
                 db=db,
@@ -201,26 +201,16 @@ def _answer_single_dormitory_chat(
         )
 
     try:
-        create_chat_retrieval_results(
-            db,
-            chat_log_id=chat_log_id,
-            retrieval_items=chunks,
-            retrieval_method=retrieval_method,
+        # 먼저 현재 검색 결과로 답변 생성
+        answer_result = generate_answer(
+            question,
+            chunks,
+            dormitory=dormitory,
+            is_fallback=retrieval_method == settings.chat_retrieval_method_fallback,
         )
-    except Exception as exc:
-        _attach_chat_error_metadata(
-            exc,
-            error_type=ERROR_TYPE_RETRIEVAL,
-            occurred_step=STEP_RETRIEVAL,
-        )
-        raise
-    db.commit()
-    try:
-        answer_result = generate_answer(question, 
-                                        chunks,
-                                        dormitory=dormitory,
-                                        is_fallback=retrieval_method == settings.chat_retrieval_method_fallback,)
 
+        # 검색 결과는 있었지만 답변 생성기가 "관련 정보를 찾을 수 없습니다."라고 한 경우
+        # 아직 fallback 검색을 하지 않은 상태라면 전체 생활관 검색으로 한 번 더 시도
         if (
             answer_result.answer.strip() == settings.chat_no_answer_message
             and retrieval_method != settings.chat_retrieval_method_fallback
@@ -237,10 +227,10 @@ def _answer_single_dormitory_chat(
                 retrieval_version = settings.chat_retrieval_version_fallback
 
                 answer_result = generate_answer(
-                    question, 
+                    question,
                     chunks,
                     dormitory=dormitory,
-                    is_fallback=retrieval_method == settings.chat_retrieval_method_fallback,
+                    is_fallback=True,
                 )
 
     except Exception as exc:
@@ -250,7 +240,27 @@ def _answer_single_dormitory_chat(
             occurred_step=STEP_ANSWER_GENERATION,
         )
         raise
+
+    # 최종적으로 사용된 chunks만 chat_retrieval_result에 저장
+    # fallback이 발생했다면 fallback chunks가 저장됨
+    try:
+        create_chat_retrieval_results(
+            db,
+            chat_log_id=chat_log_id,
+            retrieval_items=chunks,
+            retrieval_method=retrieval_method,
+        )
+    except Exception as exc:
+        _attach_chat_error_metadata(
+            exc,
+            error_type=ERROR_TYPE_RETRIEVAL,
+            occurred_step=STEP_RETRIEVAL,
+        )
+        raise
+
+    db.commit()
     db.close()
+
     return _finalize_chat_log_in_new_session(
         chat_log_id=chat_log_id,
         session_id=session_id,
@@ -265,7 +275,6 @@ def _answer_single_dormitory_chat(
         mark_retrieval_used=True,
         cited_regulation_chunk_ids=answer_result.cited_regulation_chunk_ids,
     )
-
 
 def _answer_unspecified_dormitory_chat(
     db: Session,

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -30,6 +30,9 @@ from app.services.embeddings import create_query_embedding
 from app.services.generator import generate_answer
 from app.services.validator import validate_question
 
+
+from app.repositories.regulation_chunk_repository import search_similar_chunks_all_dormitories
+
 ERROR_TYPE_TIMEOUT = "TIMEOUT"
 ERROR_TYPE_LLM_API = "LLM_API_ERROR"
 ERROR_TYPE_RETRIEVAL = "RETRIEVAL_ERROR"
@@ -150,14 +153,30 @@ def _answer_single_dormitory_chat(
     started_at: float,
 ) -> ChatResponse:
     settings = get_settings()
+
+    retrieval_method = settings.chat_retrieval_method_single
+    retrieval_version = settings.chat_retrieval_version_single
+
     try:
         query_embedding = create_query_embedding(question)
+
         chunks = search_similar_chunks(
             db=db,
             query_embedding=query_embedding,
             dormitory=dormitory,
             top_k=settings.chat_single_dormitory_top_k,
         )
+
+
+        if _should_fallback_retrieval(chunks):
+            chunks = search_similar_chunks_all_dormitories(
+                db=db,
+                query_embedding=query_embedding,
+                top_k=settings.chat_fallback_top_k,
+            )
+            retrieval_method = settings.chat_retrieval_method_fallback
+            retrieval_version = settings.chat_retrieval_version_fallback
+
     except Exception as exc:
         _attach_chat_error_metadata(
             exc,
@@ -177,7 +196,7 @@ def _answer_single_dormitory_chat(
             rewritten_query=question,
             model_name=None,
             prompt_version=None,
-            retrieval_version=settings.chat_retrieval_version_single,
+            retrieval_version=retrieval_version,
             response_time_ms=_elapsed_ms(started_at),
         )
 
@@ -186,7 +205,7 @@ def _answer_single_dormitory_chat(
             db,
             chat_log_id=chat_log_id,
             retrieval_items=chunks,
-            retrieval_method=settings.chat_retrieval_method_single,
+            retrieval_method=retrieval_method,
         )
     except Exception as exc:
         _attach_chat_error_metadata(
@@ -197,7 +216,33 @@ def _answer_single_dormitory_chat(
         raise
     db.commit()
     try:
-        answer_result = generate_answer(question, chunks)
+        answer_result = generate_answer(question, 
+                                        chunks,
+                                        dormitory=dormitory,
+                                        is_fallback=retrieval_method == settings.chat_retrieval_method_fallback,)
+
+        if (
+            answer_result.answer.strip() == settings.chat_no_answer_message
+            and retrieval_method != settings.chat_retrieval_method_fallback
+        ):
+            fallback_chunks = search_similar_chunks_all_dormitories(
+                db=db,
+                query_embedding=query_embedding,
+                top_k=settings.chat_fallback_top_k,
+            )
+
+            if fallback_chunks:
+                chunks = fallback_chunks
+                retrieval_method = settings.chat_retrieval_method_fallback
+                retrieval_version = settings.chat_retrieval_version_fallback
+
+                answer_result = generate_answer(
+                    question, 
+                    chunks,
+                    dormitory=dormitory,
+                    is_fallback=retrieval_method == settings.chat_retrieval_method_fallback,
+                )
+
     except Exception as exc:
         _attach_chat_error_metadata(
             exc,
@@ -215,7 +260,7 @@ def _answer_single_dormitory_chat(
         rewritten_query=question,
         model_name=settings.chat_answer_model,
         prompt_version=settings.chat_prompt_version_single,
-        retrieval_version=settings.chat_retrieval_version_single,
+        retrieval_version=retrieval_version,
         response_time_ms=_elapsed_ms(started_at),
         mark_retrieval_used=True,
         cited_regulation_chunk_ids=answer_result.cited_regulation_chunk_ids,
@@ -465,3 +510,16 @@ def _build_chat_error_metadata(exc: Exception) -> ChatErrorMetadata:
         error_message=error_message,
         error_detail=error_detail,
     )
+
+
+def _should_fallback_retrieval(chunks: list[dict]) -> bool:
+    settings = get_settings()
+
+    if not chunks:
+        return True
+
+    top_similarity = chunks[0].get("similarity")
+    if top_similarity is None:
+        return True
+
+    return float(top_similarity) < settings.chat_fallback_similarity_threshold

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -16,7 +16,12 @@ class AnswerGenerationResult:
     cited_regulation_chunk_ids: list[int]
 
 
-def generate_answer(question: str, chunks: list[dict]) -> AnswerGenerationResult:
+def generate_answer(
+        question: str, 
+        chunks: list[dict],
+        dormitory: Optional[str] = None,
+        is_fallback: bool = False,
+    ) -> AnswerGenerationResult:
     """
     검색된 chunk들을 기반으로 최종 답변 생성
     """
@@ -36,6 +41,19 @@ def generate_answer(question: str, chunks: list[dict]) -> AnswerGenerationResult
         ]
     )
 
+
+    fallback_instruction = ""
+    if is_fallback and dormitory:
+        fallback_instruction = f"""
+    사용자는 {dormitory} 기준으로 질문했다.
+    현재 참고 정보에는 {dormitory}가 아닌 다른 생활관 정보가 포함될 수 있다.
+    {dormitory}에 대한 직접 정보가 참고 정보에 없고, 다른 생활관 정보만 있다면
+    "{dormitory}에 대한 직접 정보는 확인되지 않지만, 다른 생활관 기준으로는 ..." 형식으로 답변해라.
+    다른 생활관 정보가 질문에 도움이 된다면 관련 정보를 찾을 수 없다고만 답하지 말고, 생활관을 구분해서 안내해라.
+    """
+
+
+
     prompt = f"""
 너는 기숙사 안내 챗봇이다.
 아래 제공된 정보를 기반으로만 질문에 답변해라.
@@ -43,6 +61,7 @@ def generate_answer(question: str, chunks: list[dict]) -> AnswerGenerationResult
 질문에서 생활관을 특정하지 않았고 참고 정보가 특정 생활관에만 해당하면, 해당 생활관 기준 답변임을 명확히 밝혀라.
 질문에서 생활관을 특정하지 않았더라도 생활관별 구분을 강제로 만들지 말고, 가장 관련 있는 정보 중심으로 간결하게 답변해라.
 참고 정보에 생활관 구분이 없거나 공통 규정으로 보이면 일반 답변으로 안내해라.
+{fallback_instruction}
 답변에는 `[C1]`, `[C2]` 같은 내부 근거 라벨을 절대 출력하지 마라.
 출처 문구는 서버가 별도로 붙이므로 답변 본문에는 출처 줄을 만들지 마라.
 질문에 답할 정보가 충분하지 않으면 정확히 "{settings.chat_no_answer_message}"라고만 답해라.


### PR DESCRIPTION
## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 변경 내용

이번 PR에서는 챗봇 검색 성능 개선을 위해 '생활관별 검색 fallback 로직'을 추가했습니다.

기존에는 사용자의 `dormitory` 값이 있는 경우 해당 생활관 문서와 공통 문서만 검색했습니다.

예를 들어 사용자가 `제1학생생활관`으로 로그인한 상태에서 편의점 위치를 질문하면, 실제 편의점 정보가 `제2학생생활관` 또는 `제3학생생활관` 문서에 있어도 검색 후보에서 제외되어 `"관련 정보를 찾을 수 없습니다."`가 반환되는 문제가 있었습니다.

이를 개선하기 위해 1차 검색 결과가 부족하거나 유사도가 낮은 경우, 전체 생활관 문서를 대상으로 fallback 검색을 수행하도록 수정했습니다.


## 주요 수정 사항

### 1. 전체 생활관 fallback 검색 함수 추가

`regulation_chunk_repository.py`에 생활관 필터 없이 전체 활성 문서를 대상으로 검색하는 함수를 추가했습니다.

- 기존 검색: 사용자의 생활관 + 공통 문서
- fallback 검색: 전체 생활관 + 공통 문서

이를 통해 사용자의 생활관에 직접 정보가 없더라도, 다른 생활관에 관련 정보가 있으면 답변에 활용할 수 있습니다.



### 2. fallback 검색 조건 추가

검색 결과가 아예 없거나, 최상위 검색 결과의 유사도 점수가 설정값보다 낮은 경우 fallback 검색을 수행하도록 했습니다.

추가된 설정값:

- `chat_fallback_top_k`
- `chat_retrieval_method_fallback`
- `chat_retrieval_version_fallback`
- `chat_fallback_similarity_threshold`

---

### 3. fallback 답변 생성 개선

fallback 검색 결과를 사용한 경우, 답변 생성 프롬프트에 사용자의 생활관 정보를 함께 전달하도록 수정했습니다.

이를 통해 다른 생활관 정보로 답변할 때 아래와 같은 형태로 안내할 수 있게 했습니다.

> 제1학생생활관에 대한 직접 정보는 확인되지 않지만, 다른 생활관 기준으로는 ...

즉, 단순히 다른 생활관 정보를 그대로 답변하는 것이 아니라, 사용자의 생활관 기준 정보가 없다는 점을 명확히 안내하도록 개선했습니다.


### 4. no answer 발생 시 fallback 재검색

1차 검색 결과가 존재하더라도, 답변 생성 결과가 `"관련 정보를 찾을 수 없습니다."`인 경우 fallback 검색을 한 번 더 수행하도록 개선했습니다.

이로 인해 검색 결과는 있었지만 실제 질문에 필요한 세부 정보가 부족했던 경우에도, 전체 생활관 문서를 다시 검색하여 답변할 수 있습니다.



## 스크린샷
<img width="1806" height="776" alt="종합프로젝트 챗봇 개선2" src="https://github.com/user-attachments/assets/8a727da3-e1d1-429e-9b4f-1552fbe01d32" />
<img width="1862" height="787" alt="종합프로젝트 챗봇 개선1" src="https://github.com/user-attachments/assets/3adbeb69-e780-4a36-8d18-8edd6946c5a7" />


