### PR TITLE
feat: 관리자 리뷰 큐 조회 api 구현

### DIFF
--- a/app/api/admin_chat.py
+++ b/app/api/admin_chat.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Optional
 
 from fastapi import APIRouter
 from fastapi import Depends
@@ -10,8 +11,11 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.admin_auth import require_admin_token
 from app.db.session import get_db
 from app.schemas.admin_chat import AdminChatLogDetail
+from app.schemas.admin_chat import AdminChatReviewQueueReason
+from app.schemas.admin_chat import AdminChatReviewQueueResult
 from app.schemas.admin_chat import AdminChatSessionsByDateResult
 from app.schemas.common import ApiResponse
+from app.services.admin_chat_service import get_admin_chat_review_queue
 from app.services.admin_chat_service import get_admin_chat_sessions_by_date
 from app.services.admin_chat_service import get_admin_chat_log_detail
 
@@ -20,6 +24,33 @@ router = APIRouter(
     tags=["admin-chat"],
     dependencies=[Depends(require_admin_token)],
 )
+
+
+@router.get(
+    "/review-queue",
+    response_model=ApiResponse[AdminChatReviewQueueResult],
+    status_code=status.HTTP_200_OK,
+    summary="관리자 리뷰 큐 조회",
+    description=(
+        "관리자가 검수해야 할 채팅 로그 목록을 페이지 단위로 조회합니다.\n\n"
+        "기본적으로 아직 `chat_admin_review`가 없는 로그 중 `ERROR`, `NO_ANSWER`, "
+        "또는 불만족 피드백이 있는 로그를 최신순으로 반환합니다.\n\n"
+        "`reason`을 전달하면 해당 사유만 필터링합니다. "
+        "사용 가능한 값은 `ERROR`, `NO_ANSWER`, `NEGATIVE_FEEDBACK`입니다."
+    ),
+)
+def get_admin_chat_review_queue_api(
+    page: int = Query(default=1, ge=1),
+    size: int = Query(default=20, ge=1, le=100),
+    reason: Optional[AdminChatReviewQueueReason] = Query(default=None),
+    db: Session = Depends(get_db),
+) -> ApiResponse[AdminChatReviewQueueResult]:
+    result = get_admin_chat_review_queue(db, page=page, size=size, reason=reason)
+    return ApiResponse(
+        status=status.HTTP_200_OK,
+        message="chat review queue retrieved",
+        data=result,
+    )
 
 
 @router.get(

--- a/app/repositories/admin_chat_repository.py
+++ b/app/repositories/admin_chat_repository.py
@@ -5,11 +5,16 @@ from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy import desc
+from sqlalchemy import exists
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.db.models.chat_admin_review import ChatAdminReview
 from app.db.models.chat_error_log import ChatErrorLog
+from app.db.models.chat_feedback import ChatFeedback
+from app.db.models.chat_enums import ChatAnswerStatus
 from app.db.models.chat_log import ChatLog
 from app.db.models.chat_retrieval_result import ChatRetrievalResult
 from app.db.models.chat_session import ChatSession
@@ -76,3 +81,91 @@ def list_chat_error_logs_by_chat_log_id(
         .order_by(ChatErrorLog.created_at.asc(), ChatErrorLog.error_id.asc())
     )
     return list(db.execute(statement).scalars().all())
+
+
+def count_chat_review_queue_items(db: Session, reason: Optional[str] = None) -> int:
+    statement = select(func.count(ChatLog.chat_log_id)).where(*_build_chat_review_queue_conditions(reason))
+    return int(db.execute(statement).scalar_one())
+
+
+def list_chat_review_queue_items(
+    db: Session,
+    *,
+    reason: Optional[str],
+    offset: int,
+    limit: int,
+) -> list[dict]:
+    negative_feedback_count = _negative_feedback_count_subquery()
+    latest_feedback_reason_code = _latest_feedback_reason_code_subquery()
+
+    statement = (
+        select(
+            ChatLog,
+            negative_feedback_count.label("negative_feedback_count"),
+            latest_feedback_reason_code.label("latest_feedback_reason_code"),
+        )
+        .where(*_build_chat_review_queue_conditions(reason))
+        .order_by(desc(ChatLog.created_at), desc(ChatLog.chat_log_id))
+        .offset(offset)
+        .limit(limit)
+    )
+    rows = db.execute(statement).all()
+    return [
+        {
+            "chat_log": row[0],
+            "negative_feedback_count": int(row.negative_feedback_count or 0),
+            "latest_feedback_reason_code": row.latest_feedback_reason_code,
+        }
+        for row in rows
+    ]
+
+
+def _build_chat_review_queue_conditions(reason: Optional[str]) -> list:
+    negative_feedback_exists = _negative_feedback_exists()
+    unreviewed = ~exists().where(ChatAdminReview.chat_log_id == ChatLog.chat_log_id)
+
+    if reason == "ERROR":
+        reason_condition = ChatLog.answer_status == ChatAnswerStatus.ERROR
+    elif reason == "NO_ANSWER":
+        reason_condition = ChatLog.answer_status == ChatAnswerStatus.NO_ANSWER
+    elif reason == "NEGATIVE_FEEDBACK":
+        reason_condition = (
+            negative_feedback_exists
+            & ChatLog.answer_status.notin_([ChatAnswerStatus.ERROR, ChatAnswerStatus.NO_ANSWER])
+        )
+    else:
+        reason_condition = or_(
+            ChatLog.answer_status.in_([ChatAnswerStatus.ERROR, ChatAnswerStatus.NO_ANSWER]),
+            negative_feedback_exists,
+        )
+
+    return [unreviewed, reason_condition]
+
+
+def _negative_feedback_exists():
+    return exists().where(
+        ChatFeedback.chat_log_id == ChatLog.chat_log_id,
+        ChatFeedback.is_helpful.is_(False),
+    )
+
+
+def _negative_feedback_count_subquery():
+    return (
+        select(func.count(ChatFeedback.feedback_id))
+        .where(ChatFeedback.chat_log_id == ChatLog.chat_log_id)
+        .where(ChatFeedback.is_helpful.is_(False))
+        .correlate(ChatLog)
+        .scalar_subquery()
+    )
+
+
+def _latest_feedback_reason_code_subquery():
+    return (
+        select(ChatFeedback.reason_code)
+        .where(ChatFeedback.chat_log_id == ChatLog.chat_log_id)
+        .where(ChatFeedback.is_helpful.is_(False))
+        .order_by(desc(ChatFeedback.created_at), desc(ChatFeedback.feedback_id))
+        .limit(1)
+        .correlate(ChatLog)
+        .scalar_subquery()
+    )

--- a/app/schemas/admin_chat.py
+++ b/app/schemas/admin_chat.py
@@ -1,9 +1,13 @@
 from datetime import date
 from datetime import datetime
+from typing import Literal
 from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
+
+
+AdminChatReviewQueueReason = Literal["ERROR", "NO_ANSWER", "NEGATIVE_FEEDBACK"]
 
 
 class AdminChatLogDetail(BaseModel):
@@ -65,3 +69,24 @@ class AdminChatSessionsByDateResult(BaseModel):
     size: int
     total_count: int
     items: list[AdminChatSessionSummary]
+
+
+class AdminChatReviewQueueItem(BaseModel):
+    chat_log_id: int
+    session_id: str
+    user_id: Optional[int] = None
+    question: str
+    answer_preview: Optional[str] = None
+    answer_status: str
+    review_reason: AdminChatReviewQueueReason
+    negative_feedback_count: int
+    latest_feedback_reason_code: Optional[str] = None
+    created_at: datetime
+
+
+class AdminChatReviewQueueResult(BaseModel):
+    page: int
+    size: int
+    total_count: int
+    total_pages: int
+    items: list[AdminChatReviewQueueItem]

--- a/app/services/admin_chat_service.py
+++ b/app/services/admin_chat_service.py
@@ -1,6 +1,7 @@
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
@@ -9,15 +10,22 @@ from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
 from app.core.time_utils import get_current_utc_time
 from app.repositories.admin_chat_repository import get_chat_log_by_id
+from app.repositories.admin_chat_repository import count_chat_review_queue_items
 from app.repositories.admin_chat_repository import count_chat_sessions_by_started_date
 from app.repositories.admin_chat_repository import list_chat_error_logs_by_chat_log_id
 from app.repositories.admin_chat_repository import list_chat_retrieval_results_by_chat_log_id
+from app.repositories.admin_chat_repository import list_chat_review_queue_items
 from app.repositories.admin_chat_repository import list_chat_sessions_by_started_date
+from app.schemas.admin_chat import AdminChatReviewQueueReason
+from app.schemas.admin_chat import AdminChatReviewQueueResult
+from app.schemas.admin_chat import AdminChatReviewQueueItem
 from app.schemas.admin_chat import AdminChatErrorLog
 from app.schemas.admin_chat import AdminChatSessionsByDateResult
 from app.schemas.admin_chat import AdminChatLogDetail
 from app.schemas.admin_chat import AdminChatRetrievalResult
 from app.schemas.admin_chat import AdminChatSessionSummary
+
+ANSWER_PREVIEW_MAX_LENGTH = 160
 
 
 def get_admin_chat_log_detail(db: Session, chat_log_id: int) -> AdminChatLogDetail:
@@ -105,5 +113,66 @@ def get_admin_chat_sessions_by_date(
     )
 
 
+def get_admin_chat_review_queue(
+    db: Session,
+    *,
+    page: int,
+    size: int,
+    reason: Optional[AdminChatReviewQueueReason] = None,
+) -> AdminChatReviewQueueResult:
+    offset = (page - 1) * size
+    total_count = count_chat_review_queue_items(db, reason)
+    rows = list_chat_review_queue_items(db, reason=reason, offset=offset, limit=size)
+
+    return AdminChatReviewQueueResult(
+        page=page,
+        size=size,
+        total_count=total_count,
+        total_pages=_calculate_total_pages(total_count, size),
+        items=[
+            AdminChatReviewQueueItem(
+                chat_log_id=row["chat_log"].chat_log_id,
+                session_id=row["chat_log"].session_id,
+                user_id=row["chat_log"].user_id,
+                question=row["chat_log"].question,
+                answer_preview=_build_answer_preview(row["chat_log"].answer),
+                answer_status=_get_answer_status_value(row["chat_log"].answer_status),
+                review_reason=_resolve_review_reason(row["chat_log"].answer_status),
+                negative_feedback_count=row["negative_feedback_count"],
+                latest_feedback_reason_code=row["latest_feedback_reason_code"],
+                created_at=row["chat_log"].created_at,
+            )
+            for row in rows
+        ],
+    )
+
+
 def _is_chat_session_expired(last_activity_at: datetime, expiration_threshold: datetime) -> bool:
     return last_activity_at < expiration_threshold
+
+
+def _calculate_total_pages(total_count: int, size: int) -> int:
+    if total_count == 0:
+        return 0
+    return (total_count + size - 1) // size
+
+
+def _build_answer_preview(answer: Optional[str]) -> Optional[str]:
+    if answer is None:
+        return None
+    if len(answer) <= ANSWER_PREVIEW_MAX_LENGTH:
+        return answer
+    return answer[:ANSWER_PREVIEW_MAX_LENGTH]
+
+
+def _resolve_review_reason(answer_status) -> AdminChatReviewQueueReason:
+    status_value = _get_answer_status_value(answer_status)
+    if status_value == "ERROR":
+        return "ERROR"
+    if status_value == "NO_ANSWER":
+        return "NO_ANSWER"
+    return "NEGATIVE_FEEDBACK"
+
+
+def _get_answer_status_value(answer_status) -> str:
+    return getattr(answer_status, "value", answer_status)

--- a/tests/test_admin_chat_api.py
+++ b/tests/test_admin_chat_api.py
@@ -5,6 +5,8 @@ from app.api import admin_chat as admin_chat_module
 from app.core.error_codes import CHAT_LOG_NOT_FOUND
 from app.core.exceptions import AppException
 from app.schemas.admin_chat import AdminChatLogDetail
+from app.schemas.admin_chat import AdminChatReviewQueueItem
+from app.schemas.admin_chat import AdminChatReviewQueueResult
 from app.schemas.admin_chat import AdminChatSessionSummary
 from app.schemas.admin_chat import AdminChatSessionsByDateResult
 
@@ -135,6 +137,99 @@ def test_get_admin_chat_log_api_returns_not_found_error(
         "data": None,
         "error_code": "CHAT_LOG_NOT_FOUND",
     }
+
+
+def test_get_admin_chat_review_queue_api_returns_paginated_queue(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    calls = {}
+
+    def fake_get_admin_chat_review_queue(_db, **kwargs):
+        calls.update(kwargs)
+        return AdminChatReviewQueueResult(
+            page=1,
+            size=20,
+            total_count=1,
+            total_pages=1,
+            items=[
+                AdminChatReviewQueueItem(
+                    chat_log_id=101,
+                    session_id="session-123",
+                    user_id=7,
+                    question="택배 어디서 받아?",
+                    answer_preview="외박 신청은 생활관 홈페이지에서...",
+                    answer_status="SUCCESS",
+                    review_reason="NEGATIVE_FEEDBACK",
+                    negative_feedback_count=1,
+                    latest_feedback_reason_code="INCORRECT_ANSWER",
+                    created_at="2026-04-30T10:00:00",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(admin_chat_module, "get_admin_chat_review_queue", fake_get_admin_chat_review_queue)
+
+    response = client.get(
+        "/api/v1/admin/chat/review-queue?page=1&size=20&reason=NEGATIVE_FEEDBACK",
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert response.status_code == 200
+    assert calls == {"page": 1, "size": 20, "reason": "NEGATIVE_FEEDBACK"}
+    assert response.json() == {
+        "status": 200,
+        "message": "chat review queue retrieved",
+        "data": {
+            "page": 1,
+            "size": 20,
+            "total_count": 1,
+            "total_pages": 1,
+            "items": [
+                {
+                    "chat_log_id": 101,
+                    "session_id": "session-123",
+                    "user_id": 7,
+                    "question": "택배 어디서 받아?",
+                    "answer_preview": "외박 신청은 생활관 홈페이지에서...",
+                    "answer_status": "SUCCESS",
+                    "review_reason": "NEGATIVE_FEEDBACK",
+                    "negative_feedback_count": 1,
+                    "latest_feedback_reason_code": "INCORRECT_ANSWER",
+                    "created_at": "2026-04-30T10:00:00",
+                }
+            ],
+        },
+        "error_code": None,
+    }
+
+
+def test_get_admin_chat_review_queue_api_accepts_missing_reason(
+    client: TestClient,
+    monkeypatch,
+) -> None:
+    calls = {}
+
+    def fake_get_admin_chat_review_queue(_db, **kwargs):
+        calls.update(kwargs)
+        return AdminChatReviewQueueResult(
+            page=1,
+            size=20,
+            total_count=0,
+            total_pages=0,
+            items=[],
+        )
+
+    monkeypatch.setattr(admin_chat_module, "get_admin_chat_review_queue", fake_get_admin_chat_review_queue)
+
+    response = client.get(
+        "/api/v1/admin/chat/review-queue",
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert response.status_code == 200
+    assert calls == {"page": 1, "size": 20, "reason": None}
+    assert response.json()["data"]["items"] == []
 
 
 def test_get_admin_chat_sessions_by_date_api_returns_paginated_sessions(

--- a/tests/test_admin_chat_service.py
+++ b/tests/test_admin_chat_service.py
@@ -146,3 +146,102 @@ def test_get_admin_chat_sessions_by_date_returns_paginated_sessions(monkeypatch:
     assert result.items[1].session_id == "session-456"
     assert result.items[0].is_expired is False
     assert result.items[1].is_expired is True
+
+
+def test_get_admin_chat_review_queue_returns_paginated_items(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {}
+    chat_log = type(
+        "ChatLogStub",
+        (),
+        {
+            "chat_log_id": 101,
+            "session_id": "session-123",
+            "user_id": 7,
+            "question": "택배 어디서 받아?",
+            "answer": "외박 신청은 생활관 홈페이지에서..." * 20,
+            "answer_status": type("StatusStub", (), {"value": "SUCCESS"})(),
+            "created_at": datetime(2026, 4, 30, 10, 0, 0),
+        },
+    )()
+
+    monkeypatch.setattr(admin_chat_service, "count_chat_review_queue_items", lambda *_args, **_kwargs: 21)
+    monkeypatch.setattr(
+        admin_chat_service,
+        "list_chat_review_queue_items",
+        lambda *_args, **kwargs: calls.update(kwargs) or [
+            {
+                "chat_log": chat_log,
+                "negative_feedback_count": 2,
+                "latest_feedback_reason_code": "INCORRECT_ANSWER",
+            }
+        ],
+    )
+
+    result = admin_chat_service.get_admin_chat_review_queue(
+        object(),
+        page=2,
+        size=10,
+        reason="NEGATIVE_FEEDBACK",
+    )
+
+    assert calls == {"reason": "NEGATIVE_FEEDBACK", "offset": 10, "limit": 10}
+    assert result.page == 2
+    assert result.size == 10
+    assert result.total_count == 21
+    assert result.total_pages == 3
+    assert len(result.items) == 1
+    assert result.items[0].chat_log_id == 101
+    assert result.items[0].review_reason == "NEGATIVE_FEEDBACK"
+    assert result.items[0].negative_feedback_count == 2
+    assert result.items[0].latest_feedback_reason_code == "INCORRECT_ANSWER"
+    assert len(result.items[0].answer_preview or "") == admin_chat_service.ANSWER_PREVIEW_MAX_LENGTH
+
+
+@pytest.mark.parametrize(
+    ("answer_status", "expected_reason"),
+    [
+        ("ERROR", "ERROR"),
+        ("NO_ANSWER", "NO_ANSWER"),
+        ("SUCCESS", "NEGATIVE_FEEDBACK"),
+    ],
+)
+def test_get_admin_chat_review_queue_resolves_review_reason_by_priority(
+    monkeypatch: pytest.MonkeyPatch,
+    answer_status: str,
+    expected_reason: str,
+) -> None:
+    chat_log = type(
+        "ChatLogStub",
+        (),
+        {
+            "chat_log_id": 101,
+            "session_id": "session-123",
+            "user_id": None,
+            "question": "택배 어디서 받아?",
+            "answer": None,
+            "answer_status": type("StatusStub", (), {"value": answer_status})(),
+            "created_at": datetime(2026, 4, 30, 10, 0, 0),
+        },
+    )()
+
+    monkeypatch.setattr(admin_chat_service, "count_chat_review_queue_items", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr(
+        admin_chat_service,
+        "list_chat_review_queue_items",
+        lambda *_args, **_kwargs: [
+            {
+                "chat_log": chat_log,
+                "negative_feedback_count": 1,
+                "latest_feedback_reason_code": "OTHER",
+            }
+        ],
+    )
+
+    result = admin_chat_service.get_admin_chat_review_queue(
+        object(),
+        page=1,
+        size=20,
+        reason=None,
+    )
+
+    assert result.items[0].review_reason == expected_reason


### PR DESCRIPTION
## 유형

- [ ] Feat
- [ ] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

<!-- 이번 PR에서 해결하는 문제와 목표를 작성해주세요. -->

## 변경 사항 (있다면)

- 변경 사항 1
- 변경 사항 2

## 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐야 할 내용을 작성해주세요. -->

## 테스트

- [ ] 로컬 실행 확인
- [ ] `/docs` 수동 확인
- [ ] `pytest` 실행

## 스크린샷
1. 관리자 리뷰 대상 큐 조회
<img width="658" height="576" alt="스크린샷 2026-04-30 오후 3 04 58" src="https://github.com/user-attachments/assets/e5af527f-b816-4626-aade-daf8c1341359" />


2. 리뷰 검수 저장
<img width="495" height="625" alt="스크린샷 2026-04-30 오후 3 53 53" src="https://github.com/user-attachments/assets/34829d17-8213-43f8-88b2-309ee1961d6b" />


3. 챗 로그 단건 조회 보강
<img width="588" height="580" alt="스크린샷 2026-04-30 오후 3 54 23" src="https://github.com/user-attachments/assets/517a1e29-25ca-4cc7-9fe7-2e83dce86c1a" />


