### PR TITLE
fix: improve grouped dormitory facility search

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -419,13 +419,36 @@ def _answer_unspecified_dormitory_chat(
         raise
 
     try:
-        chunks = search_hybrid_chunks_for_dormitories(
-            db=db,
-            query_text=question,
-            query_embedding=query_embedding,
-            dormitories=settings.chat_grouped_dormitories,
-            top_k=settings.chat_grouped_dormitory_top_k,
-        )
+        if _should_search_each_dormitory(question):
+            chunks = _search_chunks_by_each_dormitory(
+                db=db,
+                question=question,
+                query_embedding=query_embedding,
+                dormitories=settings.chat_grouped_dormitories,
+                top_k_per_dormitory=1,
+            )
+        else:
+            chunks = search_hybrid_chunks_for_dormitories(
+                db=db,
+                query_text=question,
+                query_embedding=query_embedding,
+                dormitories=settings.chat_grouped_dormitories,
+                top_k=settings.chat_grouped_dormitory_top_k,
+            )
+        
+        print("===== GROUPED SEARCH DEBUG =====")
+        print("question:", question)    
+        print("chunks_count:", len(chunks))
+        for index, chunk in enumerate(chunks, start=1):
+            print(
+                index,
+                chunk.get("document_id"),
+                chunk.get("dormitory"),
+                chunk.get("similarity"),
+                chunk.get("source"),
+                (chunk.get("content") or "")[:300],
+            )
+        print("================================")
 
 
 
@@ -865,3 +888,58 @@ def _should_pre_expand_query(question: str) -> bool:
         return True
 
     return False
+
+
+def _should_search_each_dormitory(question: str) -> bool:
+    compact_question = question.replace(" ", "")
+
+    dormitory_specific_triggers = [
+        "휴게실",
+        "다리미",
+        "편의점",
+        "전자레인지",
+        "전자렌지",
+        "정수기",
+        "세탁실",
+        "탕비실",
+        "수용인원",
+        "몇명",
+        "몇명수용",
+        "호실수",
+    ]
+
+    return any(trigger in compact_question for trigger in dormitory_specific_triggers)
+
+def _search_chunks_by_each_dormitory(
+    db: Session,
+    *,
+    question: str,
+    query_embedding: list[float],
+    dormitories: list[str],
+    top_k_per_dormitory: int = 1,
+) -> list[dict]:
+    merged_chunks: list[dict] = []
+    seen_chunk_ids: set[int] = set()
+
+    for dormitory in dormitories:
+        dormitory_chunks = search_hybrid_chunks(
+            db=db,
+            query_text=question,
+            query_embedding=query_embedding,
+            dormitory=dormitory,
+            top_k=top_k_per_dormitory,
+            candidate_k=20,
+            keyword_weight=0.3,
+        )
+
+        for chunk in dormitory_chunks:
+            regulation_chunk_id = chunk.get("regulation_chunk_id")
+
+            if regulation_chunk_id is not None:
+                if regulation_chunk_id in seen_chunk_ids:
+                    continue
+                seen_chunk_ids.add(regulation_chunk_id)
+
+            merged_chunks.append(chunk)
+
+    return merged_chunks


### PR DESCRIPTION
## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 변경 사항

- `dormitory = null` 상태에서 생활관별 시설 질문을 처리할 때, 전체 검색 top_k 안에 특정 생활관 정보가 누락되는 문제를 개선했습니다.
- 휴게실/다리미/수용인원처럼 생활관별로 정보가 달라질 수 있는 질문은 각 생활관별 검색 결과를 합쳐 답변 생성에 사용하도록 보완했습니다.

## 수정 배경

`휴게실에 뭐 있어?`처럼 생활관을 특정하지 않은 질문에서 제1, 제3학생생활관 정보는 검색되었지만 제2학생생활관 정보가 top_k 밖으로 밀려 답변에서 누락되는 문제가 있었습니다.

## 테스트

- `휴게실에 뭐 있어?` + `dormitory = null`
- `다리미 있어?` + `dormitory = null`
- `기숙사 수용 인원 어느 정도야?` + `dormitory = null`

## 기대 효과

- 생활관 미지정 상태에서 생활관별 시설/현황 정보를 더 빠짐없이 안내
- 단순히 top_k를 늘리지 않고 필요한 경우에만 생활관별 검색을 수행

