### PR TITLE
생활관 미지정 질문의 생활관별 검색 개선

### DIFF
--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -422,13 +422,18 @@ def _answer_unspecified_dormitory_chat(
         raise
 
     try:
+
+        print("should each dorm:", _should_search_each_dormitory(question))
+        print("question:", question)
+
+
         if _should_search_each_dormitory(question):
             chunks = _search_chunks_by_each_dormitory(
                 db=db,
                 question=question,
                 query_embedding=query_embedding,
                 dormitories=settings.chat_grouped_dormitories,
-                top_k_per_dormitory=1,
+                top_k_per_dormitory=3,
             )
         else:
             chunks = search_hybrid_chunks_for_dormitories(
@@ -438,20 +443,18 @@ def _answer_unspecified_dormitory_chat(
                 dormitories=settings.chat_grouped_dormitories,
                 top_k=settings.chat_grouped_dormitory_top_k,
             )
-        
-        print("===== GROUPED SEARCH DEBUG =====")
-        print("question:", question)    
+            
+        print("===== FINAL EACH DORMITORY CHUNKS =====")
         print("chunks_count:", len(chunks))
         for index, chunk in enumerate(chunks, start=1):
             print(
                 index,
                 chunk.get("document_id"),
-                chunk.get("dormitory"),
-                chunk.get("similarity"),
                 chunk.get("source"),
-                (chunk.get("content") or "")[:300],
+                (chunk.get("content") or "")[:200],
             )
-        print("================================")
+        print("======================================")
+    
 
 
 
@@ -883,7 +886,7 @@ def _should_pre_expand_query(question: str) -> bool:
     "해먹",
     "음식해",
     "음식해먹",
-    "음식 해먹"
+    "음식 해먹",
     "전기포트",
     "라면포트",
     "에어프라이어",
@@ -896,25 +899,29 @@ def _should_pre_expand_query(question: str) -> bool:
     return False
 
 
+DORMITORY_SPECIFIC_SEARCH_TRIGGERS = [
+    "휴게실",
+    "다리미",
+    "편의점",
+    "전자레인지",
+    "전자렌지",
+    "정수기",
+    "세탁실",
+    "수용인원",
+    "몇명",
+    "몇명수용",
+    "호실수",
+]
+
+
 def _should_search_each_dormitory(question: str) -> bool:
     compact_question = question.replace(" ", "")
 
-    dormitory_specific_triggers = [
-        "휴게실",
-        "다리미",
-        "편의점",
-        "전자레인지",
-        "전자렌지",
-        "정수기",
-        "세탁실",
-        "탕비실",
-        "수용인원",
-        "몇명",
-        "몇명수용",
-        "호실수",
-    ]
+    return any(
+        trigger in compact_question
+        for trigger in DORMITORY_SPECIFIC_SEARCH_TRIGGERS
+    )
 
-    return any(trigger in compact_question for trigger in dormitory_specific_triggers)
 
 def _search_chunks_by_each_dormitory(
     db: Session,
@@ -922,7 +929,7 @@ def _search_chunks_by_each_dormitory(
     question: str,
     query_embedding: list[float],
     dormitories: list[str],
-    top_k_per_dormitory: int = 1,
+    top_k_per_dormitory: int = 3,
 ) -> list[dict]:
     merged_chunks: list[dict] = []
     seen_chunk_ids: set[int] = set()
@@ -938,7 +945,12 @@ def _search_chunks_by_each_dormitory(
             keyword_weight=0.3,
         )
 
-        for chunk in dormitory_chunks:
+        dormitory_chunks = _prefer_target_dormitory_chunks(
+            dormitory_chunks,
+            dormitory,
+        )
+
+        for chunk in dormitory_chunks[:1]:
             regulation_chunk_id = chunk.get("regulation_chunk_id")
 
             if regulation_chunk_id is not None:
@@ -949,3 +961,37 @@ def _search_chunks_by_each_dormitory(
             merged_chunks.append(chunk)
 
     return merged_chunks
+
+def _prefer_target_dormitory_chunks(
+    chunks: list[dict],
+    dormitory: str,
+) -> list[dict]:
+    def score(chunk: dict) -> tuple[int, int, float]:
+        text = " ".join(
+            [
+                str(chunk.get("dormitory") or ""),
+                str(chunk.get("title") or ""),
+                str(chunk.get("source") or ""),
+                str(chunk.get("content") or ""),
+            ]
+        )
+
+        source_type = str(chunk.get("source_type") or "")
+
+        dormitory_match_score = 1 if dormitory in text else 0
+        official_score = 1 if source_type == "official" else 0
+
+        similarity = float(
+            chunk.get("similarity")
+            or chunk.get("vector_score")
+            or chunk.get("vector_similarity")
+            or 0.0
+        )
+
+        return (
+            dormitory_match_score,
+            official_score,
+            similarity,
+        )
+
+    return sorted(chunks, key=score, reverse=True)


### PR DESCRIPTION
## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 변경 사항

- `dormitory = null` 상태에서 생활관별 시설/현황 질문이 들어오면 제1·제2·제3학생생활관을 각각 검색하도록 개선했습니다.
- 기존 전체 검색 방식에서는 상위 `top_k` 안에 특정 생활관 정보가 포함되지 않아 답변에서 일부 생활관 정보가 누락될 수 있었습니다.
- 생활관별 검색 시 각 생활관마다 후보 chunk를 여러 개 가져온 뒤, 해당 생활관과 관련성이 높은 chunk를 우선 선택하도록 정렬 로직을 추가했습니다.
- 공통 팁 문서가 여러 생활관 검색에서 반복적으로 선택되어 최종 검색 결과가 하나만 남는 문제를 방지했습니다.

## 수정 배경

`dormitory = null` 상태에서 `휴게실에 뭐 있어?`처럼 전체 생활관 정보를 묻는 질문을 했을 때, 특정 생활관 정보가 검색 결과에서 누락되거나 공통 팁 문서만 선택되는 문제가 있었습니다.

예를 들어 제1·제2·제3학생생활관에 각각 휴게실 정보가 존재하더라도, 전체 검색 결과 상위 chunk에 일부 생활관 정보만 포함되면 답변도 일부 생활관 기준으로만 생성되었습니다.

이를 개선하기 위해 생활관별 시설/현황 질문에 대해서는 전체 검색에만 의존하지 않고, 각 생활관별 검색 결과를 합쳐 답변 생성에 사용하도록 수정했습니다.

## 테스트

- `휴게실에 뭐 있어?` + `dormitory = null`
- `다리미 있어?` + `dormitory = null`
- `기숙사 수용인원 몇명이야?` + `dormitory = null`

## 기대 효과

- 생활관 미지정 질문에서 특정 생활관 정보가 누락되는 문제 완화
- 생활관별 시설/현황 정보를 더 균형 있게 안내 가능
- 공통 문서가 반복 선택되어 최종 chunk가 부족해지는 문제 방지
- 단순히 전체 검색 `top_k`를 늘리지 않고 필요한 질문에서만 생활관별 검색 수행

