### PR TITLE
fix: 공지 요약 필드 문자열 정규화

### DIFF
--- a/app/services/summarizer.py
+++ b/app/services/summarizer.py
@@ -8,6 +8,22 @@ settings = get_settings()
 client = OpenAI(api_key=settings.openai_api_key)
 
 
+def _to_text(value) -> str:
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value.strip()
+
+    if isinstance(value, list):
+        return "\n".join(_to_text(item) for item in value)
+
+    if isinstance(value, dict):
+        return "\n".join(f"{key}: {_to_text(val)}" for key, val in value.items())
+
+    return str(value)
+
+
 def summarize_notice(title: str, content: str) -> NoticeSummaryData:
     settings = get_settings()
     prompt = f"""
@@ -39,9 +55,9 @@ def summarize_notice(title: str, content: str) -> NoticeSummaryData:
     payload = json.loads(response_text)
 
     return NoticeSummaryData(
-        summary=payload["summary"],
-        target_info=payload.get("target_info"),
-        schedule_info=payload.get("schedule_info"),
-        caution_info=payload.get("caution_info"),
+        summary=_to_text(payload.get("summary")),
+        target_info=_to_text(payload.get("target_info")),
+        schedule_info=_to_text(payload.get("schedule_info")),
+        caution_info=_to_text(payload.get("caution_info")),
         generated_model=response.model,
     )

--- a/app/services/summarizer.py
+++ b/app/services/summarizer.py
@@ -16,10 +16,12 @@ def _to_text(value) -> str:
         return value.strip()
 
     if isinstance(value, list):
-        return "\n".join(_to_text(item) for item in value)
+        return "\n".join(text for item in value if (text := _to_text(item)))
 
     if isinstance(value, dict):
-        return "\n".join(f"{key}: {_to_text(val)}" for key, val in value.items())
+        return "\n".join(
+            f"{key}: {text}" for key, val in value.items() if (text := _to_text(val))
+        )
 
     return str(value)
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -34,3 +34,8 @@ def test_summarize_notice_normalizes_structured_llm_fields(monkeypatch) -> None:
     assert result.schedule_info == "일시: 2026년 5월 8일 10시"
     assert result.caution_info == "귀중품은 보관해 주세요.\n소독 시간에는 협조 바랍니다."
     assert result.generated_model == "fake-model"
+
+
+def test_to_text_omits_empty_nested_values() -> None:
+    assert summarizer._to_text(["A", None, "  ", "B"]) == "A\nB"
+    assert summarizer._to_text({"대상": "전체", "비고": None, "공백": "  "}) == "대상: 전체"

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,36 @@
+import json
+from types import SimpleNamespace
+
+from app.services import summarizer
+
+
+def test_summarize_notice_normalizes_structured_llm_fields(monkeypatch) -> None:
+    payload = {
+        "summary": {"핵심": "생활관 소독 안내입니다."},
+        "target_info": {"소독 대상": "전체 생활관"},
+        "schedule_info": {"일시": "2026년 5월 8일 10시"},
+        "caution_info": ["귀중품은 보관해 주세요.", "소독 시간에는 협조 바랍니다."],
+    }
+
+    fake_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=json.dumps(payload, ensure_ascii=False))
+            )
+        ],
+        model="fake-model",
+    )
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: fake_response)
+        )
+    )
+    monkeypatch.setattr(summarizer, "client", fake_client)
+
+    result = summarizer.summarize_notice("소독 안내", "생활관 소독을 진행합니다.")
+
+    assert result.summary == "핵심: 생활관 소독 안내입니다."
+    assert result.target_info == "소독 대상: 전체 생활관"
+    assert result.schedule_info == "일시: 2026년 5월 8일 10시"
+    assert result.caution_info == "귀중품은 보관해 주세요.\n소독 시간에는 협조 바랍니다."
+    assert result.generated_model == "fake-model"


### PR DESCRIPTION

## 유형

- [ ] Feat
- [x] Fix
- [ ] Design
- [ ] Docs
- [ ] Chore
- [ ] Hotfix

## 작업 내용

공지 요약 결과 생성 시 LLM 응답의 일부 필드가 문자열이 아닌 dict/list 형태로 반환되면서 `NoticeSummaryData` 검증에 실패하는 문제를 수정했습니다.

`target_info`, `schedule_info`, `caution_info` 등 DB에 문자열로 저장되는 필드는 `NoticeSummaryData` 생성 전에 문자열로 정규화하도록 처리했습니다.

## 변경 사항 (있다면)

- `summarizer.py`에 `_to_text()` 정규화 함수 추가
- `summary`, `target_info`, `schedule_info`, `caution_info` 필드에 문자열 정규화 적용
- dict/list 형태의 LLM 응답이 들어와도 정상 처리되는 테스트 추가

## 리뷰 포인트

- dict/list 응답을 문자열로 변환하는 방식이 DB 저장 형식과 API 응답 의도에 맞는지 확인 부탁드립니다.
- `None` 값이 빈 문자열로 변환된 뒤 기존 Pydantic validator에서 `None`으로 정리되는 흐름이 적절한지 봐주세요.

## 테스트

- [x] 로컬 실행 확인
- [ ] `/docs` 수동 확인
- [x] `pytest` 실행

## 스크린샷
